### PR TITLE
add rate limiting middleware

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,7 +3,6 @@ import { randomUUID } from 'node:crypto';
 import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
-import rateLimit from 'express-rate-limit';
 import { verificationRouter } from './routes/verification.js';
 import { invoiceRouter } from './routes/invoice.js';
 import { stellarRouter } from './routes/stellar.js';
@@ -12,6 +11,7 @@ import { jobsRouter } from './routes/jobs.js';
 import { healthRouter } from './routes/health.js';
 import { startJobs, getJobScheduler } from './jobs/index.js';
 import { errorHandler, notFoundHandler } from './middleware/errorHandler.js';
+import { generalLimiter, invoiceLimiter } from './middleware/rateLimit.js';
 
 dotenv.config();
 
@@ -47,20 +47,6 @@ const PORT = process.env.PORT || 3001;
 const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS
   ? process.env.CORS_ALLOWED_ORIGINS.split(',').map((origin) => origin.trim())
   : '*';
-
-const generalLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 100,
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-const invoiceLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 20,
-  standardHeaders: true,
-  legacyHeaders: false,
-});
 
 app.use(
   cors({

--- a/backend/src/middleware/__tests__/rateLimit.test.ts
+++ b/backend/src/middleware/__tests__/rateLimit.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { generalLimiter, invoiceLimiter } from '../rateLimit.js';
+
+describe('Rate Limit Middleware', () => {
+  describe('generalLimiter', () => {
+    it('should be defined', () => {
+      expect(generalLimiter).toBeDefined();
+    });
+
+    it('should be a function', () => {
+      expect(typeof generalLimiter).toBe('function');
+    });
+  });
+
+  describe('invoiceLimiter', () => {
+    it('should be defined', () => {
+      expect(invoiceLimiter).toBeDefined();
+    });
+
+    it('should be a function', () => {
+      expect(typeof invoiceLimiter).toBe('function');
+    });
+  });
+
+  describe('Rate limit configuration', () => {
+    it('generalLimiter and invoiceLimiter should be different instances', () => {
+      expect(generalLimiter).not.toBe(invoiceLimiter);
+    });
+
+    it('both limiters should be express middleware functions', () => {
+      expect(generalLimiter.length).toBeGreaterThanOrEqual(0);
+      expect(invoiceLimiter.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -1,0 +1,27 @@
+import rateLimit from 'express-rate-limit';
+
+export const generalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: {
+      code: 'RATE_LIMIT_EXCEEDED',
+      message: 'Too many requests, please try again later',
+    },
+  },
+});
+
+export const invoiceLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: {
+      code: 'RATE_LIMIT_EXCEEDED',
+      message: 'Too many invoice requests, please try again later',
+    },
+  },
+});


### PR DESCRIPTION
Closes #8 
- Add express-rate-limit middleware with 100 req/15min for general API routes
- Add stricter 20 req/15min limit for invoice routes
- Return 429 with RATE_LIMIT_EXCEEDED code when limit exceeded
- Include RateLimit-* headers in responses