### PR TITLE
feat(backend): feature flag system with usage tracking and gradual rollout

### DIFF
--- a/backend/src/config/__tests__/featureFlags.test.ts
+++ b/backend/src/config/__tests__/featureFlags.test.ts
@@ -1,0 +1,248 @@
+/**
+ * featureFlags.test.ts
+ *
+ * Unit tests for the FeatureFlagRegistry:
+ *   - Flag definitions and defaults
+ *   - Env-var override parsing (true / false / N%)
+ *   - evaluate() — all strategies (all, none, percentage, allowlist)
+ *   - Usage tracking (counters, lastEvaluatedAt)
+ *   - override() — force enable/disable, rollout %, allowlist
+ *   - reset() — restores to default
+ *   - Gradual rollout consistency (same identifier always same result)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ─── Re-usable registry factory ───────────────────────────────────────────────
+// We import the module fresh inside each test via dynamic import so that
+// environment-variable reads (done once at module load) can be varied.
+
+async function loadRegistry(envOverrides: Record<string, string> = {}) {
+  // Apply env overrides before the module loads
+  for (const [k, v] of Object.entries(envOverrides)) {
+    process.env[k] = v;
+  }
+
+  // Force a fresh module (clear Vitest's module cache)
+  vi.resetModules();
+  const { featureFlags } = await import('../featureFlags.js');
+
+  return featureFlags;
+}
+
+function cleanup(envKeys: string[]) {
+  for (const k of envKeys) delete process.env[k];
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Flag definitions', () => {
+  it('registers all expected flags', async () => {
+    const ff = await loadRegistry();
+    const names = ff.getAll().map((f) => f.definition.name);
+
+    expect(names).toContain('ai-verification');
+    expect(names).toContain('bulk-verification');
+    expect(names).toContain('batch-operations');
+    expect(names).toContain('job-scheduling');
+    expect(names).toContain('message-queue');
+    expect(names).toContain('rate-limit-tiering');
+    expect(names).toContain('sla-tracking');
+    expect(names).toContain('response-caching');
+  });
+
+  it('ai-verification is enabled by default', async () => {
+    const ff = await loadRegistry();
+    expect(ff.evaluate('ai-verification')).toBe(true);
+  });
+
+  it('get() returns null for unknown flags', async () => {
+    const ff = await loadRegistry();
+    expect(ff.get('unknown-flag' as any)).toBeNull();
+  });
+
+  it('evaluate() returns false and logs warning for unknown flags', async () => {
+    const ff = await loadRegistry();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = ff.evaluate('unknown-flag' as any);
+    expect(result).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('unknown-flag'));
+    warn.mockRestore();
+  });
+});
+
+describe('Environment variable override', () => {
+  afterEach(() => cleanup(['FEATURE_AI_VERIFICATION', 'FEATURE_BULK_VERIFICATION', 'FEATURE_RATE_LIMIT_TIERING']));
+
+  it('FEATURE_<NAME>=true force-enables a flag', async () => {
+    const ff = await loadRegistry({ FEATURE_AI_VERIFICATION: 'true' });
+    expect(ff.evaluate('ai-verification')).toBe(true);
+    expect(ff.get('ai-verification')!.currentStrategy).toBe('all');
+    expect(ff.get('ai-verification')!.overridden).toBe(true);
+  });
+
+  it('FEATURE_<NAME>=false force-disables a flag', async () => {
+    const ff = await loadRegistry({ FEATURE_AI_VERIFICATION: 'false' });
+    expect(ff.evaluate('ai-verification')).toBe(false);
+    expect(ff.get('ai-verification')!.currentStrategy).toBe('none');
+  });
+
+  it('FEATURE_<NAME>=50% sets percentage rollout', async () => {
+    const ff = await loadRegistry({ FEATURE_BULK_VERIFICATION: '50%' });
+    const state = ff.get('bulk-verification')!;
+    expect(state.currentStrategy).toBe('percentage');
+    expect(state.currentRolloutPercentage).toBe(50);
+  });
+
+  it('unrecognised env value falls back to default and logs warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ff = await loadRegistry({ FEATURE_RATE_LIMIT_TIERING: 'maybe' });
+    expect(ff.evaluate('rate-limit-tiering')).toBe(true); // default is true
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('FEATURE_RATE_LIMIT_TIERING'));
+    warn.mockRestore();
+  });
+});
+
+describe('evaluate() — strategies', () => {
+  it('strategy=all returns true regardless of identifier', async () => {
+    const ff = await loadRegistry();
+    expect(ff.evaluate('ai-verification', 'user-A')).toBe(true);
+    expect(ff.evaluate('ai-verification', 'user-B')).toBe(true);
+    expect(ff.evaluate('ai-verification', 'anon')).toBe(true);
+  });
+
+  it('strategy=none returns false regardless of identifier', async () => {
+    const ff = await loadRegistry();
+    ff.override('ai-verification', { enabled: false });
+    expect(ff.evaluate('ai-verification', 'user-A')).toBe(false);
+    expect(ff.evaluate('ai-verification', 'premium')).toBe(false);
+  });
+
+  it('strategy=percentage 0% disables for all callers', async () => {
+    const ff = await loadRegistry();
+    ff.override('response-caching', { rolloutPercentage: 0 });
+    for (let i = 0; i < 50; i++) {
+      expect(ff.evaluate('response-caching', `user-${i}`)).toBe(false);
+    }
+  });
+
+  it('strategy=percentage 100% enables for all callers', async () => {
+    const ff = await loadRegistry();
+    ff.override('response-caching', { rolloutPercentage: 100 });
+    for (let i = 0; i < 50; i++) {
+      expect(ff.evaluate('response-caching', `user-${i}`)).toBe(true);
+    }
+  });
+
+  it('strategy=percentage ~50% enables roughly half', async () => {
+    const ff = await loadRegistry();
+    ff.override('bulk-verification', { rolloutPercentage: 50 });
+
+    const enabled = Array.from({ length: 200 }, (_, i) =>
+      ff.evaluate('bulk-verification', `user-${i}`),
+    ).filter(Boolean).length;
+
+    // Should be between 30% and 70% (statistical tolerance)
+    expect(enabled).toBeGreaterThan(60);
+    expect(enabled).toBeLessThan(140);
+  });
+
+  it('strategy=percentage is hash-stable (same id always same result)', async () => {
+    const ff = await loadRegistry();
+    ff.override('bulk-verification', { rolloutPercentage: 30 });
+
+    const id = 'stable-user-id-xyz';
+    const first = ff.evaluate('bulk-verification', id);
+    for (let i = 0; i < 20; i++) {
+      expect(ff.evaluate('bulk-verification', id)).toBe(first);
+    }
+  });
+
+  it('strategy=allowlist enables only listed identifiers', async () => {
+    const ff = await loadRegistry();
+    ff.override('ai-verification', { allowlist: ['alice', 'bob'] });
+
+    expect(ff.evaluate('ai-verification', 'alice')).toBe(true);
+    expect(ff.evaluate('ai-verification', 'bob')).toBe(true);
+    expect(ff.evaluate('ai-verification', 'charlie')).toBe(false);
+    expect(ff.evaluate('ai-verification', '')).toBe(false);
+  });
+});
+
+describe('Usage tracking', () => {
+  it('increments totalEvaluations on each call', async () => {
+    const ff = await loadRegistry();
+    ff.evaluate('catalog' as any);  // unknown → still increments in wrapper path
+    ff.evaluate('ai-verification');
+    ff.evaluate('ai-verification');
+    ff.evaluate('ai-verification');
+
+    const state = ff.get('ai-verification')!;
+    expect(state.usage.totalEvaluations).toBe(3);
+  });
+
+  it('increments enabledCount / disabledCount correctly', async () => {
+    const ff = await loadRegistry();
+    ff.override('bulk-verification', { rolloutPercentage: 50 });
+
+    let en = 0, dis = 0;
+    for (let i = 0; i < 100; i++) {
+      ff.evaluate('bulk-verification', `u${i}`) ? en++ : dis++;
+    }
+
+    const stats = ff.get('bulk-verification')!.usage;
+    expect(stats.totalEvaluations).toBe(100);
+    expect(stats.enabledCount).toBe(en);
+    expect(stats.disabledCount).toBe(dis);
+    expect(stats.enabledCount + stats.disabledCount).toBe(100);
+  });
+
+  it('records lastEvaluatedAt as an ISO timestamp after first call', async () => {
+    const ff = await loadRegistry();
+    expect(ff.get('sla-tracking')!.usage.lastEvaluatedAt).toBeNull();
+
+    ff.evaluate('sla-tracking');
+
+    const ts = ff.get('sla-tracking')!.usage.lastEvaluatedAt;
+    expect(ts).not.toBeNull();
+    expect(() => new Date(ts!)).not.toThrow();
+  });
+});
+
+describe('override() and reset()', () => {
+  it('override() force-enables a flag', async () => {
+    const ff = await loadRegistry();
+    ff.override('batch-operations', { enabled: false });
+    expect(ff.evaluate('batch-operations')).toBe(false);
+
+    ff.override('batch-operations', { enabled: true });
+    expect(ff.evaluate('batch-operations')).toBe(true);
+    expect(ff.get('batch-operations')!.overridden).toBe(true);
+  });
+
+  it('override() throws for unknown flag', async () => {
+    const ff = await loadRegistry();
+    expect(() => ff.override('ghost' as any, { enabled: true })).toThrow();
+  });
+
+  it('override() throws when rolloutPercentage is out of range', async () => {
+    const ff = await loadRegistry();
+    expect(() => ff.override('ai-verification', { rolloutPercentage: 101 })).toThrow();
+    expect(() => ff.override('ai-verification', { rolloutPercentage: -1 })).toThrow();
+  });
+
+  it('reset() restores flag to default strategy', async () => {
+    const ff = await loadRegistry();
+    ff.override('ai-verification', { enabled: false });
+    expect(ff.evaluate('ai-verification')).toBe(false);
+
+    ff.reset('ai-verification');
+    expect(ff.evaluate('ai-verification')).toBe(true); // default is true / strategy=all
+    expect(ff.get('ai-verification')!.overridden).toBe(false);
+  });
+
+  it('reset() on unknown flag is a no-op (does not throw)', async () => {
+    const ff = await loadRegistry();
+    expect(() => ff.reset('ghost' as any)).not.toThrow();
+  });
+});

--- a/backend/src/config/featureFlags.ts
+++ b/backend/src/config/featureFlags.ts
@@ -1,0 +1,385 @@
+/**
+ * featureFlags.ts
+ *
+ * Feature flag system for AgenticPay backend.
+ *
+ * ## Features
+ *
+ * - **Define flags** — typed registry with description, default, and rollout strategy
+ * - **Toggle via config** — env var `FEATURE_<NAME>=true|false|<N>%` overrides defaults
+ * - **Track usage** — per-flag counters: total evaluations, enabled hits, disabled hits
+ * - **Gradual rollout** — percentage-based rollout using a consistent FNV-1a hash of a
+ *   caller-supplied identifier (IP, user ID, API key) so the same caller always gets
+ *   the same result across requests
+ *
+ * ## Environment variable format
+ *
+ * | Value       | Effect                                       |
+ * |-------------|----------------------------------------------|
+ * | `true`      | Force-enable for all callers                 |
+ * | `false`     | Force-disable for all callers                |
+ * | `25%`       | Enable for ~25 % of callers (hash-stable)    |
+ * | _(absent)_  | Use the flag's `defaultEnabled` value         |
+ *
+ * Example:
+ *   ```
+ *   FEATURE_AI_VERIFICATION=false
+ *   FEATURE_BULK_VERIFICATION=50%
+ *   FEATURE_MESSAGE_QUEUE=true
+ *   ```
+ *
+ * ## Runtime override (for testing / gradual rollout via API)
+ *
+ *   ```ts
+ *   featureFlags.override('ai-verification', { enabled: false });
+ *   featureFlags.override('bulk-verification', { rolloutPercentage: 25 });
+ *   featureFlags.reset('ai-verification');
+ *   ```
+ */
+
+// ─── Rollout strategies ───────────────────────────────────────────────────────
+
+/**
+ * - `all`        — enabled for every caller
+ * - `none`       — disabled for every caller
+ * - `percentage` — enabled for a hash-stable percentage of callers
+ * - `allowlist`  — enabled only for callers whose identifier appears in the list
+ */
+export type RolloutStrategy = 'all' | 'none' | 'percentage' | 'allowlist';
+
+// ─── Flag definitions ─────────────────────────────────────────────────────────
+
+export interface FeatureFlagDefinition {
+  /** Unique machine-readable identifier (kebab-case). */
+  name: FeatureFlagName;
+  /** Human-readable description shown in the admin API. */
+  description: string;
+  /** Enabled by default when no env-var override is present. */
+  defaultEnabled: boolean;
+  /** How to decide whether a given caller gets this feature. */
+  strategy: RolloutStrategy;
+  /** Percentage (0–100) of callers to enable — only used with `strategy: 'percentage'`. */
+  rolloutPercentage?: number;
+  /** Explicit list of identifiers to enable — only used with `strategy: 'allowlist'`. */
+  allowlist?: string[];
+}
+
+/** All known feature flag names. Extend this union when adding new flags. */
+export type FeatureFlagName =
+  | 'ai-verification'
+  | 'bulk-verification'
+  | 'batch-operations'
+  | 'job-scheduling'
+  | 'message-queue'
+  | 'rate-limit-tiering'
+  | 'sla-tracking'
+  | 'response-caching';
+
+// ─── Runtime state ────────────────────────────────────────────────────────────
+
+export interface FlagUsageStats {
+  /** Total times this flag was evaluated. */
+  totalEvaluations: number;
+  /** Times the evaluation returned `true`. */
+  enabledCount: number;
+  /** Times the evaluation returned `false`. */
+  disabledCount: number;
+  /** ISO timestamp of the most recent evaluation, or null if never evaluated. */
+  lastEvaluatedAt: string | null;
+}
+
+export interface FlagState {
+  definition: FeatureFlagDefinition;
+  /** Current effective strategy (may differ from definition if overridden at runtime). */
+  currentStrategy: RolloutStrategy;
+  /** Current effective rollout percentage (may differ from definition if overridden). */
+  currentRolloutPercentage: number;
+  /** Whether the flag has been runtime-overridden (vs. config/default value). */
+  overridden: boolean;
+  usage: FlagUsageStats;
+}
+
+// ─── Override config ──────────────────────────────────────────────────────────
+
+export interface FlagOverrideConfig {
+  /** Force-enable (`true`) or force-disable (`false`) for all callers. */
+  enabled?: boolean;
+  /** Set rollout percentage (0–100). Automatically sets strategy to `'percentage'`. */
+  rolloutPercentage?: number;
+  /** Replace the allowlist. Automatically sets strategy to `'allowlist'`. */
+  allowlist?: string[];
+}
+
+// ─── Built-in flag definitions ────────────────────────────────────────────────
+
+const FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
+  {
+    name: 'ai-verification',
+    description: 'AI-powered work verification via OpenAI — requires OPENAI_API_KEY',
+    defaultEnabled: true,
+    strategy: 'all',
+  },
+  {
+    name: 'bulk-verification',
+    description: 'Bulk AI verification endpoint (POST /verification/verify/batch)',
+    defaultEnabled: true,
+    strategy: 'all',
+  },
+  {
+    name: 'batch-operations',
+    description: 'Bulk update and delete operations on verification results',
+    defaultEnabled: true,
+    strategy: 'all',
+  },
+  {
+    name: 'job-scheduling',
+    description: 'Background job scheduler (mirrors JOBS_ENABLED env var)',
+    defaultEnabled: process.env.JOBS_ENABLED !== 'false',
+    strategy: 'all',
+  },
+  {
+    name: 'message-queue',
+    description: 'In-process message queue for async task processing',
+    defaultEnabled: process.env.QUEUE_ENABLED !== 'false',
+    strategy: 'all',
+  },
+  {
+    name: 'rate-limit-tiering',
+    description: 'Tiered rate limiting (free/pro/enterprise) based on X-User-Tier header',
+    defaultEnabled: true,
+    strategy: 'all',
+  },
+  {
+    name: 'sla-tracking',
+    description: 'SLA tracking middleware — records request latencies for SLA reporting',
+    defaultEnabled: true,
+    strategy: 'all',
+  },
+  {
+    name: 'response-caching',
+    description: 'ETag-based HTTP response caching on stable GET endpoints',
+    defaultEnabled: true,
+    strategy: 'percentage',
+    rolloutPercentage: 100,
+  },
+];
+
+// ─── Consistent-hash helper ───────────────────────────────────────────────────
+
+/**
+ * FNV-1a 32-bit hash of a string, returned as a value in [0, 99].
+ * Using a stable hash ensures the same identifier always maps to the
+ * same bucket — critical for gradual rollout so users don't flip on/off.
+ */
+function hashToBucket(identifier: string): number {
+  let hash = 2166136261; // FNV offset basis
+  for (let i = 0; i < identifier.length; i++) {
+    hash ^= identifier.charCodeAt(i);
+    // Unsigned 32-bit multiply
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  return hash % 100;
+}
+
+// ─── FeatureFlagRegistry ─────────────────────────────────────────────────────
+
+class FeatureFlagRegistry {
+  private readonly state = new Map<FeatureFlagName, FlagState>();
+
+  constructor(definitions: FeatureFlagDefinition[]) {
+    for (const def of definitions) {
+      const envOverride = this.readEnvOverride(def.name);
+      this.state.set(def.name, {
+        definition: { ...def },
+        currentStrategy: envOverride?.strategy ?? def.strategy,
+        currentRolloutPercentage: envOverride?.rolloutPercentage ?? def.rolloutPercentage ?? 100,
+        overridden: envOverride !== null,
+        usage: {
+          totalEvaluations: 0,
+          enabledCount: 0,
+          disabledCount: 0,
+          lastEvaluatedAt: null,
+        },
+      });
+    }
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  /**
+   * Evaluates a flag for a given caller identifier.
+   *
+   * @param name        The feature flag name.
+   * @param identifier  Optional caller identifier (IP, user ID, API key) used
+   *                    for hash-based percentage rollout and allowlist checks.
+   *                    Defaults to `'anonymous'` when omitted.
+   * @returns `true` if the feature is enabled for this caller, `false` otherwise.
+   */
+  evaluate(name: FeatureFlagName, identifier = 'anonymous'): boolean {
+    const flagState = this.state.get(name);
+    if (!flagState) {
+      console.warn(`[FeatureFlags] Unknown flag '${name}' evaluated — defaulting to false`);
+      return false;
+    }
+
+    const result = this.computeResult(flagState, identifier);
+    this.recordUsage(flagState, result);
+    return result;
+  }
+
+  /**
+   * Returns the current state and usage stats for all registered flags.
+   */
+  getAll(): FlagState[] {
+    return Array.from(this.state.values()).map((s) => ({ ...s, usage: { ...s.usage } }));
+  }
+
+  /**
+   * Returns the current state for a single flag, or `null` if not found.
+   */
+  get(name: FeatureFlagName): FlagState | null {
+    const s = this.state.get(name);
+    return s ? { ...s, usage: { ...s.usage } } : null;
+  }
+
+  /**
+   * Applies a runtime override to a flag.
+   * Useful for canary deployments, A/B tests, and emergency kill-switches.
+   *
+   * @param name   The flag to override.
+   * @param config What to change.
+   */
+  override(name: FeatureFlagName, config: FlagOverrideConfig): void {
+    const flagState = this.state.get(name);
+    if (!flagState) {
+      throw new Error(`[FeatureFlags] Cannot override unknown flag '${name}'`);
+    }
+
+    if (config.enabled !== undefined) {
+      flagState.currentStrategy = config.enabled ? 'all' : 'none';
+    }
+
+    if (config.rolloutPercentage !== undefined) {
+      if (config.rolloutPercentage < 0 || config.rolloutPercentage > 100) {
+        throw new Error(`rolloutPercentage must be between 0 and 100`);
+      }
+      flagState.currentStrategy = 'percentage';
+      flagState.currentRolloutPercentage = config.rolloutPercentage;
+    }
+
+    if (config.allowlist !== undefined) {
+      flagState.currentStrategy = 'allowlist';
+      flagState.definition.allowlist = config.allowlist;
+    }
+
+    flagState.overridden = true;
+
+    console.info(
+      `[FeatureFlags] '${name}' overridden → strategy=${flagState.currentStrategy}` +
+      (flagState.currentStrategy === 'percentage' ? ` (${flagState.currentRolloutPercentage}%)` : ''),
+    );
+  }
+
+  /**
+   * Resets a flag back to its default (definition + env-var) state.
+   */
+  reset(name: FeatureFlagName): void {
+    const flagState = this.state.get(name);
+    if (!flagState) return;
+
+    const def = flagState.definition;
+    const envOverride = this.readEnvOverride(name);
+
+    flagState.currentStrategy = envOverride?.strategy ?? def.strategy;
+    flagState.currentRolloutPercentage =
+      envOverride?.rolloutPercentage ?? def.rolloutPercentage ?? 100;
+    flagState.overridden = envOverride !== null;
+
+    console.info(`[FeatureFlags] '${name}' reset to ${flagState.currentStrategy}`);
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private computeResult(flagState: FlagState, identifier: string): boolean {
+    switch (flagState.currentStrategy) {
+      case 'all':
+        return true;
+
+      case 'none':
+        return false;
+
+      case 'percentage': {
+        const bucket = hashToBucket(identifier);
+        return bucket < flagState.currentRolloutPercentage;
+      }
+
+      case 'allowlist': {
+        const list = flagState.definition.allowlist ?? [];
+        return list.includes(identifier);
+      }
+
+      default:
+        return false;
+    }
+  }
+
+  private recordUsage(flagState: FlagState, result: boolean): void {
+    flagState.usage.totalEvaluations += 1;
+    if (result) {
+      flagState.usage.enabledCount += 1;
+    } else {
+      flagState.usage.disabledCount += 1;
+    }
+    flagState.usage.lastEvaluatedAt = new Date().toISOString();
+  }
+
+  /**
+   * Parses `FEATURE_<NAME>` environment variable.
+   *
+   * | Env value | Parsed strategy     |
+   * |-----------|---------------------|
+   * | `true`    | `all`               |
+   * | `false`   | `none`              |
+   * | `25%`     | `percentage` (25)   |
+   * | absent    | `null` (use default)|
+   */
+  private readEnvOverride(
+    name: FeatureFlagName,
+  ): { strategy: RolloutStrategy; rolloutPercentage?: number } | null {
+    const envKey = `FEATURE_${name.toUpperCase().replace(/-/g, '_')}`;
+    const raw = process.env[envKey];
+    if (raw === undefined) return null;
+
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed === 'true')  return { strategy: 'all' };
+    if (trimmed === 'false') return { strategy: 'none' };
+
+    const pctMatch = trimmed.match(/^(\d+(?:\.\d+)?)%$/);
+    if (pctMatch) {
+      const pct = Math.min(100, Math.max(0, parseFloat(pctMatch[1])));
+      return { strategy: 'percentage', rolloutPercentage: pct };
+    }
+
+    console.warn(
+      `[FeatureFlags] Unrecognised value for ${envKey}="${raw}" — expected true|false|<N>%. Using default.`,
+    );
+    return null;
+  }
+}
+
+// ─── Singleton ────────────────────────────────────────────────────────────────
+
+/**
+ * The global feature flag registry. Import this singleton wherever flag
+ * evaluation is needed.
+ *
+ * @example
+ * ```ts
+ * import { featureFlags } from '../config/featureFlags.js';
+ *
+ * if (featureFlags.evaluate('ai-verification', req.ip)) {
+ *   // run AI path
+ * }
+ * ```
+ */
+export const featureFlags = new FeatureFlagRegistry(FLAG_DEFINITIONS);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,7 @@ import { registerDefaultProcessors } from './services/queue-producers.js';
 import { slaTrackingMiddleware } from './middleware/slaTracking.js';
 import { requestIdMiddleware, REQUEST_ID_HEADER } from './middleware/requestId.js';
 import { validateEnv, config as getConfig } from './config/env.js';
+import { flagsRouter } from './routes/flags.js';
 
 // Validate environment variables at startup
 validateEnv();
@@ -213,6 +214,8 @@ apiV1Router.use('/jobs', jobsRouter);
 apiV1Router.use('/queue', queueRouter);
 apiV1Router.use('/sla', slaRouter);
 apiV1Router.use('/legacy', legacyRouter);
+// Feature flag admin — inspect & override flags at runtime
+apiV1Router.use('/flags', flagsRouter);
 
 app.use('/api/v1', apiV1Router);
 

--- a/backend/src/middleware/requireFlag.ts
+++ b/backend/src/middleware/requireFlag.ts
@@ -1,0 +1,60 @@
+/**
+ * requireFlag.ts
+ *
+ * Express middleware factory that gates a route behind a feature flag.
+ *
+ * The caller identifier used for percentage/allowlist rollout is resolved
+ * in this order:
+ *   1. `X-User-Id` header (explicit user identifier)
+ *   2. `Authorization` header value (token-based identity)
+ *   3. `X-Api-Key` header
+ *   4. `req.ip` (client IP address)
+ *   5. `'anonymous'` (fallback)
+ *
+ * @example
+ * ```ts
+ * import { requireFlag } from '../middleware/requireFlag.js';
+ *
+ * // Block the whole router if the flag is off
+ * router.use(requireFlag('bulk-verification'));
+ *
+ * // Or gate a single route
+ * router.post('/verify/batch', requireFlag('bulk-verification'), handler);
+ * ```
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { featureFlags, FeatureFlagName } from '../config/featureFlags.js';
+import { AppError } from './errorHandler.js';
+
+export function requireFlag(flagName: FeatureFlagName) {
+  return function featureFlagGate(req: Request, _res: Response, next: NextFunction): void {
+    const identifier = resolveIdentifier(req);
+
+    if (!featureFlags.evaluate(flagName, identifier)) {
+      next(
+        new AppError(
+          403,
+          `Feature '${flagName}' is not available`,
+          'FEATURE_DISABLED',
+        ),
+      );
+      return;
+    }
+
+    next();
+  };
+}
+
+function resolveIdentifier(req: Request): string {
+  const userId = req.headers['x-user-id'];
+  if (typeof userId === 'string' && userId.trim()) return userId.trim();
+
+  const auth = req.headers.authorization;
+  if (auth) return auth;
+
+  const apiKey = req.headers['x-api-key'];
+  if (typeof apiKey === 'string' && apiKey.trim()) return apiKey.trim();
+
+  return req.ip ?? 'anonymous';
+}

--- a/backend/src/routes/flags.ts
+++ b/backend/src/routes/flags.ts
@@ -1,0 +1,107 @@
+/**
+ * flags.ts — Admin endpoints for inspecting and overriding feature flags.
+ *
+ * Routes (all under /api/v1/flags):
+ *
+ *   GET  /              — list all flags with current state and usage stats
+ *   GET  /:name         — get a single flag
+ *   PATCH /:name        — runtime override (enabled, rolloutPercentage, allowlist)
+ *   POST  /:name/reset  — reset a flag to its default / env-var value
+ */
+
+import { Router } from 'express';
+import { featureFlags, FeatureFlagName } from '../config/featureFlags.js';
+import { AppError, asyncHandler } from '../middleware/errorHandler.js';
+
+export const flagsRouter = Router();
+
+// GET /api/v1/flags
+flagsRouter.get(
+  '/',
+  asyncHandler(async (_req, res) => {
+    res.json({
+      flags: featureFlags.getAll().map(serializeFlag),
+      total: featureFlags.getAll().length,
+    });
+  }),
+);
+
+// GET /api/v1/flags/:name
+flagsRouter.get(
+  '/:name',
+  asyncHandler(async (req, res) => {
+    const name = req.params.name as FeatureFlagName;
+    const flag = featureFlags.get(name);
+
+    if (!flag) {
+      throw new AppError(404, `Feature flag '${name}' not found`, 'NOT_FOUND');
+    }
+
+    res.json(serializeFlag(flag));
+  }),
+);
+
+// PATCH /api/v1/flags/:name
+// Body: { enabled?: boolean, rolloutPercentage?: number, allowlist?: string[] }
+flagsRouter.patch(
+  '/:name',
+  asyncHandler(async (req, res) => {
+    const name = req.params.name as FeatureFlagName;
+
+    if (!featureFlags.get(name)) {
+      throw new AppError(404, `Feature flag '${name}' not found`, 'NOT_FOUND');
+    }
+
+    const { enabled, rolloutPercentage, allowlist } = req.body as {
+      enabled?: boolean;
+      rolloutPercentage?: number;
+      allowlist?: string[];
+    };
+
+    const hasUpdate = enabled !== undefined || rolloutPercentage !== undefined || allowlist !== undefined;
+    if (!hasUpdate) {
+      throw new AppError(400, 'Provide at least one of: enabled, rolloutPercentage, allowlist', 'VALIDATION_ERROR');
+    }
+
+    if (rolloutPercentage !== undefined && (rolloutPercentage < 0 || rolloutPercentage > 100)) {
+      throw new AppError(400, 'rolloutPercentage must be between 0 and 100', 'VALIDATION_ERROR');
+    }
+
+    featureFlags.override(name, { enabled, rolloutPercentage, allowlist });
+
+    const updated = featureFlags.get(name)!;
+    res.json(serializeFlag(updated));
+  }),
+);
+
+// POST /api/v1/flags/:name/reset
+flagsRouter.post(
+  '/:name/reset',
+  asyncHandler(async (req, res) => {
+    const name = req.params.name as FeatureFlagName;
+
+    if (!featureFlags.get(name)) {
+      throw new AppError(404, `Feature flag '${name}' not found`, 'NOT_FOUND');
+    }
+
+    featureFlags.reset(name);
+
+    const reset = featureFlags.get(name)!;
+    res.json(serializeFlag(reset));
+  }),
+);
+
+// ─── Serialiser ───────────────────────────────────────────────────────────────
+
+function serializeFlag(flag: ReturnType<typeof featureFlags.get>) {
+  if (!flag) return null;
+  return {
+    name:               flag.definition.name,
+    description:        flag.definition.description,
+    defaultEnabled:     flag.definition.defaultEnabled,
+    currentStrategy:    flag.currentStrategy,
+    rolloutPercentage:  flag.currentRolloutPercentage,
+    overridden:         flag.overridden,
+    usage:              flag.usage,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a complete feature flag system to the AgenticPay backend, satisfying all four acceptance criteria.

## New files

| File | Purpose |
|------|---------|
| `backend/src/config/featureFlags.ts` | Core registry (as specified) — definitions, evaluation, usage tracking, overrides |
| `backend/src/middleware/requireFlag.ts` | Route-gating middleware |
| `backend/src/routes/flags.ts` | Admin REST API (GET / PATCH / POST reset) |
| `backend/src/config/__tests__/featureFlags.test.ts` | 23 unit tests |

## Acceptance criteria

### ✅ Define feature flags
8 typed flags registered with description, default, and rollout strategy:
`ai-verification`, `bulk-verification`, `batch-operations`, `job-scheduling`, `message-queue`, `rate-limit-tiering`, `sla-tracking`, `response-caching`

### ✅ Toggle via config
- **Env vars** at startup: `FEATURE_AI_VERIFICATION=false`, `FEATURE_BULK_VERIFICATION=25%`, `FEATURE_JOB_SCHEDULING=true`
- **Runtime API**: `PATCH /api/v1/flags/:name` → `{ enabled, rolloutPercentage, allowlist }`
- **Programmatic**: `featureFlags.override(name, config)` / `featureFlags.reset(name)`
- **Middleware**: `requireFlag('"ai-verification"')` returns 403 when disabled

### ✅ Track usage
Every `evaluate()` call increments `totalEvaluations`, `enabledCount`, `disabledCount`, and updates `lastEvaluatedAt`. Visible via `GET /api/v1/flags`.

### ✅ Gradual rollout
`strategy: '"percentage"'` uses a stable FNV-1a hash of the caller identifier (resolved from `X-User-Id` → `Authorization` → `X-Api-Key` → IP). Same caller always gets the same result — no flip-flopping across requests. `strategy: '"allowlist"'` restricts to an explicit set of identifiers.

## Test plan
- [x] 23 unit tests pass: `npx vitest run src/config/__tests__/featureFlags.test.ts`
- [ ] `GET /api/v1/flags` returns all 8 flags with usage stats
- [ ] `PATCH /api/v1/flags/ai-verification` `{ enabled: false }` disables flag, subsequent calls get 403
- [ ] `POST /api/v1/flags/ai-verification/reset` restores original behaviour
- [ ] Set `FEATURE_BULK_VERIFICATION=25%` in env, restart — verify ~25% of callers are enabled

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)