### PR TITLE
feat: migrate Web3 state management to Zustand with persistence (#203)

### DIFF
--- a/frontend/components/providers.tsx
+++ b/frontend/components/providers.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react';
 import { toast } from 'sonner';
 import { Toaster } from '@/components/ui/sonner';
 import { OfflineProvider } from '@/components/offline/OfflineProvider';
+import { Web3StoreProvider } from '@/components/providers/Web3StoreProvider';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
@@ -31,16 +32,18 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <OfflineProvider>
-          {children}
-          <Toaster />
-          <button 
-            onClick={() => setNotificationsEnabled(!notificationsEnabled)}
-            className="fixed bottom-4 right-4 z-50 px-3 py-1 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-md shadow-sm text-sm"
-          >
-            {notificationsEnabled ? 'Disable Notifications' : 'Enable Notifications'}
-          </button>
-        </OfflineProvider>
+        <Web3StoreProvider>
+          <OfflineProvider>
+            {children}
+            <Toaster />
+            <button
+              onClick={() => setNotificationsEnabled(!notificationsEnabled)}
+              className="fixed bottom-4 right-4 z-50 px-3 py-1 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-md shadow-sm text-sm"
+            >
+              {notificationsEnabled ? 'Disable Notifications' : 'Enable Notifications'}
+            </button>
+          </OfflineProvider>
+        </Web3StoreProvider>
       </QueryClientProvider>
     </WagmiProvider>
   );

--- a/frontend/components/providers/Web3StoreProvider.tsx
+++ b/frontend/components/providers/Web3StoreProvider.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useWeb3Sync } from '@/lib/hooks/useWeb3';
+
+/**
+ * Mounts the wagmi→Zustand sync bridge.
+ * Must be rendered inside <WagmiProvider> + <QueryClientProvider>.
+ * Renders no DOM — pure side-effect component.
+ */
+export function Web3StoreProvider({ children }: { children: React.ReactNode }) {
+  useWeb3Sync();
+  return <>{children}</>;
+}

--- a/frontend/lib/hooks/useWeb3.ts
+++ b/frontend/lib/hooks/useWeb3.ts
@@ -1,0 +1,176 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useAccount, useChainId } from 'wagmi';
+import { useShallow } from 'zustand/react/shallow';
+import {
+  useWeb3Store,
+  selectAccount,
+  selectChainId,
+  selectIsConnected,
+  selectIsConnecting,
+  selectIsReconnecting,
+  selectProviderType,
+  selectConnectionError,
+  selectPendingTxs,
+  type ProviderType,
+  type TxStatus,
+  type TransactionRecord,
+} from '@/store/web3Store';
+
+// ─── Auto-reconnect + wagmi sync ──────────────────────────────────────────────
+
+/**
+ * Syncs wagmi's live connection state into the Zustand Web3 store.
+ * Auto-reconnection is handled by wagmi (ssr: true in wagmiConfig) — this hook
+ * keeps the store consistent once wagmi resolves the reconnect attempt.
+ *
+ * Mount exactly once inside <WagmiProvider> via <Web3StoreProvider>.
+ */
+export function useWeb3Sync(): void {
+  const { address, isConnected, isConnecting, isReconnecting } = useAccount();
+  const chainId = useChainId();
+  const { setConnected, setConnecting, setReconnecting, disconnect } = useWeb3Store();
+
+  useEffect(() => {
+    setConnecting(isConnecting);
+  }, [isConnecting, setConnecting]);
+
+  useEffect(() => {
+    setReconnecting(isReconnecting);
+  }, [isReconnecting, setReconnecting]);
+
+  useEffect(() => {
+    if (isConnected && address) {
+      setConnected(address, chainId ?? 1, 'injected' as ProviderType);
+    } else if (!isConnected && !isConnecting && !isReconnecting) {
+      disconnect();
+    }
+  }, [isConnected, address, chainId, isConnecting, isReconnecting, setConnected, disconnect]);
+}
+
+// ─── Network change subscriber ────────────────────────────────────────────────
+
+/**
+ * Subscribes to chainId changes in the Web3 store.
+ * Works outside React (no hook rules). Returns an unsubscribe function.
+ *
+ * @example
+ * const unsub = subscribeToNetworkChange((chainId) => {
+ *   if (chainId === 11155111) console.log('switched to Sepolia');
+ * });
+ * // later: unsub();
+ */
+export function subscribeToNetworkChange(
+  handler: (chainId: number | null, prevChainId: number | null) => void
+): () => void {
+  return useWeb3Store.subscribe(selectChainId, handler);
+}
+
+/**
+ * Subscribes to account changes in the Web3 store.
+ * Works outside React (no hook rules). Returns an unsubscribe function.
+ */
+export function subscribeToAccountChange(
+  handler: (account: `0x${string}` | null, prev: `0x${string}` | null) => void
+): () => void {
+  return useWeb3Store.subscribe(selectAccount, handler);
+}
+
+/**
+ * Subscribes to connection status changes.
+ */
+export function subscribeToConnectionChange(
+  handler: (isConnected: boolean, prev: boolean) => void
+): () => void {
+  return useWeb3Store.subscribe(selectIsConnected, handler);
+}
+
+// ─── React hook for Web3 state ────────────────────────────────────────────────
+
+interface Web3HookResult {
+  account: `0x${string}` | null;
+  chainId: number | null;
+  isConnected: boolean;
+  isConnecting: boolean;
+  isReconnecting: boolean;
+  providerType: ProviderType;
+  connectionError: string | null;
+  pendingTransactions: TransactionRecord[];
+  addTransaction: (tx: Omit<TransactionRecord, 'timestamp'>) => void;
+  updateTransaction: (hash: string, status: TxStatus) => void;
+  clearTransactions: () => void;
+}
+
+/**
+ * Convenience hook. Re-renders only when selected fields change (shallow equality).
+ */
+export function useWeb3(): Web3HookResult {
+  const state = useWeb3Store(
+    useShallow((s) => ({
+      account: s.account,
+      chainId: s.chainId,
+      isConnected: s.isConnected,
+      isConnecting: s.isConnecting,
+      isReconnecting: s.isReconnecting,
+      providerType: s.providerType,
+      connectionError: s.connectionError,
+    }))
+  );
+
+  const pendingTransactions = useWeb3Store(selectPendingTxs);
+  const addTransaction = useWeb3Store((s) => s.addTransaction);
+  const updateTransaction = useWeb3Store((s) => s.updateTransaction);
+  const clearTransactions = useWeb3Store((s) => s.clearTransactions);
+
+  return { ...state, pendingTransactions, addTransaction, updateTransaction, clearTransactions };
+}
+
+// ─── Network change hook (React) ──────────────────────────────────────────────
+
+/**
+ * React hook that fires a callback whenever the connected chain changes.
+ *
+ * @example
+ * useNetworkChangeEffect((chainId) => {
+ *   toast(`Switched to chain ${chainId}`);
+ * });
+ */
+export function useNetworkChangeEffect(
+  handler: (chainId: number | null) => void
+): void {
+  useEffect(() => {
+    const unsub = subscribeToNetworkChange(handler);
+    return unsub;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+// ─── Transaction queue hook ───────────────────────────────────────────────────
+
+interface TransactionQueueResult {
+  transactions: TransactionRecord[];
+  pendingCount: number;
+  addTransaction: (tx: Omit<TransactionRecord, 'timestamp'>) => void;
+  updateTransaction: (hash: string, status: TxStatus) => void;
+  clearTransactions: () => void;
+}
+
+/**
+ * Hook scoped to the transaction queue slice — components that only care about
+ * transactions won't re-render on account/chain changes.
+ */
+export function useTransactionQueue(): TransactionQueueResult {
+  const transactions = useWeb3Store((s) => s.transactions);
+  const addTransaction = useWeb3Store((s) => s.addTransaction);
+  const updateTransaction = useWeb3Store((s) => s.updateTransaction);
+  const clearTransactions = useWeb3Store((s) => s.clearTransactions);
+
+  return {
+    transactions,
+    pendingCount: transactions.filter((tx) => tx.status === 'pending').length,
+    addTransaction,
+    updateTransaction,
+    clearTransactions,
+  };
+}

--- a/frontend/store/web3Store.ts
+++ b/frontend/store/web3Store.ts
@@ -1,0 +1,271 @@
+'use client';
+
+import { create } from 'zustand';
+import { devtools, persist, subscribeWithSelector, createJSONStorage } from 'zustand/middleware';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ProviderType = 'injected' | 'walletconnect' | 'web3auth' | null;
+export type TxStatus = 'pending' | 'confirmed' | 'failed';
+
+export interface TransactionRecord {
+  hash: string;
+  status: TxStatus;
+  description?: string;
+  timestamp: number;
+  chainId: number;
+  from?: string;
+  to?: string;
+  value?: string;
+}
+
+interface Web3State {
+  account: `0x${string}` | null;
+  chainId: number | null;
+  isConnected: boolean;
+  isConnecting: boolean;
+  isReconnecting: boolean;
+  providerType: ProviderType;
+  connectionError: string | null;
+  transactions: TransactionRecord[];
+}
+
+interface Web3Actions {
+  setAccount: (account: `0x${string}` | null) => void;
+  setChainId: (chainId: number | null) => void;
+  setConnecting: (v: boolean) => void;
+  setReconnecting: (v: boolean) => void;
+  setConnected: (account: `0x${string}`, chainId: number, providerType: ProviderType) => void;
+  setConnectionError: (error: string | null) => void;
+  disconnect: () => void;
+  addTransaction: (tx: Omit<TransactionRecord, 'timestamp'>) => void;
+  updateTransaction: (hash: string, status: TxStatus) => void;
+  clearTransactions: () => void;
+}
+
+export type Web3Store = Web3State & Web3Actions;
+
+// Persisted slice — only serialisable fields
+type PersistedWeb3 = Pick<
+  Web3State,
+  'account' | 'chainId' | 'providerType' | 'isConnected' | 'transactions'
+>;
+
+// ─── Lightweight XOR-based storage encryption ─────────────────────────────────
+// Obfuscates persisted data from casual localStorage inspection.
+
+const CIPHER_KEY = 'agenticpay-w3-2024';
+
+function xorCipher(str: string): string {
+  return str
+    .split('')
+    .map((ch, i) =>
+      String.fromCharCode(ch.charCodeAt(0) ^ CIPHER_KEY.charCodeAt(i % CIPHER_KEY.length))
+    )
+    .join('');
+}
+
+const encryptedStorage = createJSONStorage<PersistedWeb3>(() => ({
+  getItem: (name: string): string | null => {
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(name);
+    if (!raw) return null;
+    try {
+      return xorCipher(atob(raw));
+    } catch {
+      // Fallback: return raw so an unencrypted legacy value still hydrates
+      return raw;
+    }
+  },
+  setItem: (name: string, value: string): void => {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(name, btoa(xorCipher(value)));
+  },
+  removeItem: (name: string): void => {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem(name);
+  },
+}));
+
+// ─── BroadcastChannel cross-tab sync ─────────────────────────────────────────
+
+type SyncMessage =
+  | { type: 'CONNECTED'; account: string; chainId: number; providerType: ProviderType }
+  | { type: 'DISCONNECTED' }
+  | { type: 'CHAIN_CHANGED'; chainId: number }
+  | { type: 'TX_UPDATE'; hash: string; status: TxStatus };
+
+let _channel: BroadcastChannel | null = null;
+
+function getChannel(): BroadcastChannel | null {
+  if (typeof window === 'undefined' || !('BroadcastChannel' in window)) return null;
+  if (!_channel) _channel = new BroadcastChannel('agenticpay-web3-sync');
+  return _channel;
+}
+
+function broadcast(msg: SyncMessage): void {
+  try {
+    getChannel()?.postMessage(msg);
+  } catch {
+    // Private mode or iframe isolation — fail silently
+  }
+}
+
+// ─── Initial state ────────────────────────────────────────────────────────────
+
+const INITIAL_STATE: Web3State = {
+  account: null,
+  chainId: null,
+  isConnected: false,
+  isConnecting: false,
+  isReconnecting: false,
+  providerType: null,
+  connectionError: null,
+  transactions: [],
+};
+
+// ─── Store ────────────────────────────────────────────────────────────────────
+
+export const useWeb3Store = create<Web3Store>()(
+  devtools(
+    subscribeWithSelector(
+      persist(
+        (set) => ({
+          ...INITIAL_STATE,
+
+          setAccount: (account) =>
+            set({ account }, false, 'web3/setAccount'),
+
+          setChainId: (chainId) => {
+            set({ chainId }, false, 'web3/setChainId');
+            if (chainId !== null) broadcast({ type: 'CHAIN_CHANGED', chainId });
+          },
+
+          setConnecting: (isConnecting) =>
+            set({ isConnecting }, false, 'web3/setConnecting'),
+
+          setReconnecting: (isReconnecting) =>
+            set({ isReconnecting }, false, 'web3/setReconnecting'),
+
+          setConnected: (account, chainId, providerType) => {
+            set(
+              { account, chainId, providerType, isConnected: true, isConnecting: false, connectionError: null },
+              false,
+              'web3/setConnected'
+            );
+            broadcast({ type: 'CONNECTED', account, chainId, providerType });
+          },
+
+          setConnectionError: (connectionError) =>
+            set({ connectionError, isConnecting: false }, false, 'web3/setConnectionError'),
+
+          disconnect: () => {
+            set({ ...INITIAL_STATE }, false, 'web3/disconnect');
+            broadcast({ type: 'DISCONNECTED' });
+          },
+
+          addTransaction: (tx) =>
+            set(
+              (state) => ({
+                transactions: [{ ...tx, timestamp: Date.now() }, ...state.transactions].slice(0, 50),
+              }),
+              false,
+              'web3/addTransaction'
+            ),
+
+          updateTransaction: (hash, status) => {
+            set(
+              (state) => ({
+                transactions: state.transactions.map((tx) =>
+                  tx.hash === hash ? { ...tx, status } : tx
+                ),
+              }),
+              false,
+              'web3/updateTransaction'
+            );
+            broadcast({ type: 'TX_UPDATE', hash, status });
+          },
+
+          clearTransactions: () =>
+            set({ transactions: [] }, false, 'web3/clearTransactions'),
+        }),
+        {
+          name: 'agenticpay-web3',
+          storage: encryptedStorage,
+          // Only persist serialisable, non-sensitive connection markers
+          partialize: (state): PersistedWeb3 => ({
+            account: state.account,
+            chainId: state.chainId,
+            providerType: state.providerType,
+            isConnected: state.isConnected,
+            transactions: state.transactions,
+          }),
+        }
+      )
+    ),
+    {
+      name: 'AgenticPay/Web3',
+      enabled: process.env.NODE_ENV === 'development',
+    }
+  )
+);
+
+// ─── Cross-tab message handler ────────────────────────────────────────────────
+// Uses setState directly (not actions) to avoid re-broadcasting.
+
+if (typeof window !== 'undefined') {
+  const ch = getChannel();
+  if (ch) {
+    ch.onmessage = (event: MessageEvent<SyncMessage>) => {
+      const msg = event.data;
+      switch (msg.type) {
+        case 'CONNECTED':
+          useWeb3Store.setState(
+            {
+              account: msg.account as `0x${string}`,
+              chainId: msg.chainId,
+              providerType: msg.providerType,
+              isConnected: true,
+              isConnecting: false,
+              connectionError: null,
+            },
+            false
+          );
+          break;
+        case 'DISCONNECTED':
+          useWeb3Store.setState({ ...INITIAL_STATE }, false);
+          break;
+        case 'CHAIN_CHANGED':
+          useWeb3Store.setState({ chainId: msg.chainId }, false);
+          break;
+        case 'TX_UPDATE':
+          useWeb3Store.setState(
+            (state) => ({
+              transactions: state.transactions.map((tx) =>
+                tx.hash === msg.hash ? { ...tx, status: msg.status } : tx
+              ),
+            }),
+            false
+          );
+          break;
+      }
+    };
+  }
+}
+
+// ─── Type-safe selectors ──────────────────────────────────────────────────────
+
+export const selectAccount = (s: Web3Store) => s.account;
+export const selectChainId = (s: Web3Store) => s.chainId;
+export const selectIsConnected = (s: Web3Store) => s.isConnected;
+export const selectIsConnecting = (s: Web3Store) => s.isConnecting;
+export const selectIsReconnecting = (s: Web3Store) => s.isReconnecting;
+export const selectProviderType = (s: Web3Store) => s.providerType;
+export const selectConnectionError = (s: Web3Store) => s.connectionError;
+export const selectTransactions = (s: Web3Store) => s.transactions;
+export const selectPendingTxs = (s: Web3Store) =>
+  s.transactions.filter((tx) => tx.status === 'pending');
+export const selectConfirmedTxs = (s: Web3Store) =>
+  s.transactions.filter((tx) => tx.status === 'confirmed');
+export const selectFailedTxs = (s: Web3Store) =>
+  s.transactions.filter((tx) => tx.status === 'failed');


### PR DESCRIPTION
Closes #203

frontend/store/web3Store.ts (new)

Zustand store for all Web3 state: account, chainId, providerType, isConnected, isConnecting, isReconnecting, connectionError
persist middleware with XOR+base64 encryption — obfuscates localStorage data from casual inspection; falls back gracefully on legacy unencrypted data
devtools middleware active in development only for state inspection
subscribeWithSelector middleware enabling reactive slice subscriptions
Transaction queue (addTransaction / updateTransaction / clearTransactions) — persisted, capped at 50 entries
BroadcastChannel cross-tab sync — broadcasts CONNECTED / DISCONNECTED / CHAIN_CHANGED / TX_UPDATE; handler uses setState directly (not actions) to prevent re-broadcast loops; silently no-ops in private mode / iframe isolation
Type-safe selectors: selectAccount, selectChainId, selectIsConnected, selectPendingTxs, selectConfirmedTxs, selectFailedTxs, and more
frontend/lib/hooks/useWeb3.ts (new)

useWeb3Sync — syncs wagmi live state into the store; auto-reconnect is handled by wagmi (ssr: true), this keeps the store consistent once wagmi resolves
useWeb3 — shallow-equality hook returning connection fields + pendingTransactions; only re-renders on actual field changes
useTransactionQueue — scoped hook for tx-only components
useNetworkChangeEffect — React hook wrapping the network change subscription
subscribeToNetworkChange / subscribeToAccountChange / subscribeToConnectionChange — static subscribers usable outside React (e.g. service workers, analytics)
frontend/components/providers/Web3StoreProvider.tsx (new) — mounts useWeb3Sync once inside <WagmiProvider>

frontend/components/providers.tsx — wraps app tree with <Web3StoreProvider>