### PR TITLE
feat: Receipt NFTs, Event Sourcing, Threat Detection, Service Mesh

### DIFF
--- a/backend/src/events/event-bus.ts
+++ b/backend/src/events/event-bus.ts
@@ -1,0 +1,37 @@
+import type { DomainEventType, EventHandler, StoredEvent } from './event-types.js';
+
+type WildcardHandler = (event: StoredEvent) => void | Promise<void>;
+
+const handlers = new Map<string, Set<EventHandler>>();
+let wildcardHandlers: Set<WildcardHandler> = new Set();
+
+export function subscribe<T = unknown>(type: DomainEventType, handler: EventHandler<T>): () => void {
+  const set = handlers.get(type) ?? new Set<EventHandler>();
+  set.add(handler as EventHandler);
+  handlers.set(type, set);
+
+  return () => {
+    set.delete(handler as EventHandler);
+  };
+}
+
+export function subscribeAll(handler: WildcardHandler): () => void {
+  wildcardHandlers.add(handler);
+  return () => wildcardHandlers.delete(handler);
+}
+
+export async function publish(event: StoredEvent): Promise<void> {
+  const typed = handlers.get(event.type);
+  if (typed) {
+    await Promise.all(Array.from(typed).map((h) => h(event)));
+  }
+
+  if (wildcardHandlers.size > 0) {
+    await Promise.all(Array.from(wildcardHandlers).map((h) => h(event)));
+  }
+}
+
+export function clearHandlers(): void {
+  handlers.clear();
+  wildcardHandlers = new Set();
+}

--- a/backend/src/events/event-store.ts
+++ b/backend/src/events/event-store.ts
@@ -1,0 +1,126 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  DomainEvent,
+  DomainEventType,
+  EventMetadata,
+  EventStream,
+  StoredEvent,
+} from './event-types.js';
+
+export interface AppendOptions {
+  expectedVersion?: number;
+}
+
+export interface TemporalQuery {
+  aggregateId: string;
+  aggregateType: string;
+  asOf: string;
+}
+
+const streams = new Map<string, EventStream>();
+const globalSequence: StoredEvent[] = [];
+
+function streamKey(aggregateType: string, aggregateId: string): string {
+  return `${aggregateType}:${aggregateId}`;
+}
+
+export function appendEvent<T>(
+  aggregateType: string,
+  aggregateId: string,
+  type: DomainEventType,
+  payload: T,
+  metadata: EventMetadata = {},
+  opts: AppendOptions = {}
+): StoredEvent<T> {
+  const key = streamKey(aggregateType, aggregateId);
+  const now = new Date().toISOString();
+
+  let stream = streams.get(key);
+  if (!stream) {
+    stream = {
+      streamId: key,
+      aggregateId,
+      aggregateType,
+      version: 0,
+      events: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  if (opts.expectedVersion !== undefined && stream.version !== opts.expectedVersion) {
+    throw new Error(
+      `Optimistic concurrency conflict: expected version ${opts.expectedVersion}, got ${stream.version}`
+    );
+  }
+
+  const nextVersion = stream.version + 1;
+  const sequenceNumber = globalSequence.length + 1;
+
+  const event: DomainEvent<T> = {
+    id: randomUUID(),
+    type,
+    aggregateId,
+    aggregateType,
+    version: nextVersion,
+    payload,
+    metadata,
+    occurredAt: now,
+  };
+
+  const stored: StoredEvent<T> = { ...event, sequenceNumber, streamId: key };
+
+  stream.events.push(stored as StoredEvent);
+  stream.version = nextVersion;
+  stream.updatedAt = now;
+
+  streams.set(key, stream);
+  globalSequence.push(stored as StoredEvent);
+
+  return stored;
+}
+
+export function loadStream(aggregateType: string, aggregateId: string): EventStream | undefined {
+  return streams.get(streamKey(aggregateType, aggregateId));
+}
+
+export function loadEvents(
+  aggregateType: string,
+  aggregateId: string,
+  fromVersion = 0
+): StoredEvent[] {
+  const stream = streams.get(streamKey(aggregateType, aggregateId));
+  if (!stream) return [];
+  return stream.events.filter((e) => e.version > fromVersion);
+}
+
+export function loadSnapshot(query: TemporalQuery): StoredEvent[] {
+  const stream = streams.get(streamKey(query.aggregateType, query.aggregateId));
+  if (!stream) return [];
+  const asOfMs = new Date(query.asOf).getTime();
+  return stream.events.filter((e) => new Date(e.occurredAt).getTime() <= asOfMs);
+}
+
+export function getAllEvents(fromSequence = 0): StoredEvent[] {
+  return globalSequence.filter((e) => e.sequenceNumber > fromSequence);
+}
+
+export function getEventsByType(type: DomainEventType): StoredEvent[] {
+  return globalSequence.filter((e) => e.type === type);
+}
+
+export function getAllStreams(): EventStream[] {
+  return Array.from(streams.values());
+}
+
+export function getEventStats() {
+  const typeCounts: Record<string, number> = {};
+  for (const e of globalSequence) {
+    typeCounts[e.type] = (typeCounts[e.type] ?? 0) + 1;
+  }
+  return {
+    totalEvents: globalSequence.length,
+    totalStreams: streams.size,
+    typeCounts,
+  };
+}

--- a/backend/src/events/event-types.ts
+++ b/backend/src/events/event-types.ts
@@ -1,0 +1,90 @@
+export type DomainEventType =
+  | 'payment.created'
+  | 'payment.executed'
+  | 'payment.failed'
+  | 'payment.cancelled'
+  | 'project.created'
+  | 'project.funded'
+  | 'project.work_submitted'
+  | 'project.work_approved'
+  | 'project.disputed'
+  | 'project.cancelled'
+  | 'project.completed'
+  | 'verification.requested'
+  | 'verification.passed'
+  | 'verification.failed'
+  | 'invoice.generated'
+  | 'receipt.minted'
+  | 'receipt.transferred'
+  | 'receipt.burned'
+  | 'refund.requested'
+  | 'refund.approved'
+  | 'refund.rejected'
+  | 'split.created'
+  | 'split.executed';
+
+export interface DomainEvent<T = unknown> {
+  id: string;
+  type: DomainEventType;
+  aggregateId: string;
+  aggregateType: string;
+  version: number;
+  payload: T;
+  metadata: EventMetadata;
+  occurredAt: string;
+}
+
+export interface EventMetadata {
+  correlationId?: string;
+  causationId?: string;
+  userId?: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+export interface StoredEvent<T = unknown> extends DomainEvent<T> {
+  sequenceNumber: number;
+  streamId: string;
+}
+
+export interface EventStream {
+  streamId: string;
+  aggregateId: string;
+  aggregateType: string;
+  version: number;
+  events: StoredEvent[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type EventHandler<T = unknown> = (event: StoredEvent<T>) => void | Promise<void>;
+
+export interface PaymentCreatedPayload {
+  from: string;
+  to: string;
+  amount: number;
+  asset: string;
+  trigger: { type: string; executeAt?: string };
+}
+
+export interface ProjectFundedPayload {
+  projectId: string;
+  client: string;
+  amount: number;
+}
+
+export interface VerificationPayload {
+  projectId: string;
+  repositoryUrl: string;
+  score?: number;
+  summary?: string;
+}
+
+export interface ReceiptMintedPayload {
+  tokenId: string;
+  paymentId: string;
+  sender: string;
+  recipient: string;
+  amount: number;
+  asset: string;
+}

--- a/backend/src/events/projections.ts
+++ b/backend/src/events/projections.ts
@@ -1,0 +1,173 @@
+import { subscribe } from './event-bus.js';
+import type { StoredEvent } from './event-types.js';
+
+export interface PaymentReadModel {
+  paymentId: string;
+  from: string;
+  to: string;
+  amount: number;
+  asset: string;
+  status: 'pending' | 'executed' | 'failed' | 'cancelled';
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectReadModel {
+  projectId: string;
+  client: string;
+  freelancer?: string;
+  amount: number;
+  status: string;
+  repoUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VerificationReadModel {
+  verificationId: string;
+  projectId: string;
+  repositoryUrl: string;
+  status: 'requested' | 'passed' | 'failed';
+  score?: number;
+  summary?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const paymentProjection = new Map<string, PaymentReadModel>();
+const projectProjection = new Map<string, ProjectReadModel>();
+const verificationProjection = new Map<string, VerificationReadModel>();
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+subscribe('payment.created', (event: StoredEvent) => {
+  const p = event.payload as { from: string; to: string; amount: number; asset: string };
+  paymentProjection.set(event.aggregateId, {
+    paymentId: event.aggregateId,
+    from: p.from,
+    to: p.to,
+    amount: p.amount,
+    asset: p.asset,
+    status: 'pending',
+    createdAt: event.occurredAt,
+    updatedAt: event.occurredAt,
+  });
+});
+
+subscribe('payment.executed', (event: StoredEvent) => {
+  const m = paymentProjection.get(event.aggregateId);
+  if (m) paymentProjection.set(event.aggregateId, { ...m, status: 'executed', updatedAt: now() });
+});
+
+subscribe('payment.failed', (event: StoredEvent) => {
+  const m = paymentProjection.get(event.aggregateId);
+  if (m) paymentProjection.set(event.aggregateId, { ...m, status: 'failed', updatedAt: now() });
+});
+
+subscribe('payment.cancelled', (event: StoredEvent) => {
+  const m = paymentProjection.get(event.aggregateId);
+  if (m) paymentProjection.set(event.aggregateId, { ...m, status: 'cancelled', updatedAt: now() });
+});
+
+subscribe('project.created', (event: StoredEvent) => {
+  const p = event.payload as { client: string; amount: number };
+  projectProjection.set(event.aggregateId, {
+    projectId: event.aggregateId,
+    client: p.client,
+    amount: p.amount,
+    status: 'created',
+    createdAt: event.occurredAt,
+    updatedAt: event.occurredAt,
+  });
+});
+
+subscribe('project.funded', (event: StoredEvent) => {
+  const m = projectProjection.get(event.aggregateId);
+  if (m) projectProjection.set(event.aggregateId, { ...m, status: 'funded', updatedAt: now() });
+});
+
+subscribe('project.work_submitted', (event: StoredEvent) => {
+  const p = event.payload as { repoUrl?: string };
+  const m = projectProjection.get(event.aggregateId);
+  if (m)
+    projectProjection.set(event.aggregateId, {
+      ...m,
+      status: 'work_submitted',
+      repoUrl: p.repoUrl,
+      updatedAt: now(),
+    });
+});
+
+subscribe('project.work_approved', (event: StoredEvent) => {
+  const m = projectProjection.get(event.aggregateId);
+  if (m) projectProjection.set(event.aggregateId, { ...m, status: 'completed', updatedAt: now() });
+});
+
+subscribe('project.disputed', (event: StoredEvent) => {
+  const m = projectProjection.get(event.aggregateId);
+  if (m) projectProjection.set(event.aggregateId, { ...m, status: 'disputed', updatedAt: now() });
+});
+
+subscribe('verification.requested', (event: StoredEvent) => {
+  const p = event.payload as { projectId: string; repositoryUrl: string };
+  verificationProjection.set(event.aggregateId, {
+    verificationId: event.aggregateId,
+    projectId: p.projectId,
+    repositoryUrl: p.repositoryUrl,
+    status: 'requested',
+    createdAt: event.occurredAt,
+    updatedAt: event.occurredAt,
+  });
+});
+
+subscribe('verification.passed', (event: StoredEvent) => {
+  const p = event.payload as { score?: number; summary?: string };
+  const m = verificationProjection.get(event.aggregateId);
+  if (m)
+    verificationProjection.set(event.aggregateId, {
+      ...m,
+      status: 'passed',
+      score: p.score,
+      summary: p.summary,
+      updatedAt: now(),
+    });
+});
+
+subscribe('verification.failed', (event: StoredEvent) => {
+  const p = event.payload as { score?: number; summary?: string };
+  const m = verificationProjection.get(event.aggregateId);
+  if (m)
+    verificationProjection.set(event.aggregateId, {
+      ...m,
+      status: 'failed',
+      score: p.score,
+      summary: p.summary,
+      updatedAt: now(),
+    });
+});
+
+export function getPaymentReadModel(paymentId: string): PaymentReadModel | undefined {
+  return paymentProjection.get(paymentId);
+}
+
+export function getAllPayments(): PaymentReadModel[] {
+  return Array.from(paymentProjection.values());
+}
+
+export function getProjectReadModel(projectId: string): ProjectReadModel | undefined {
+  return projectProjection.get(projectId);
+}
+
+export function getAllProjects(): ProjectReadModel[] {
+  return Array.from(projectProjection.values());
+}
+
+export function getVerificationReadModel(verificationId: string): VerificationReadModel | undefined {
+  return verificationProjection.get(verificationId);
+}
+
+export function getAllVerifications(): VerificationReadModel[] {
+  return Array.from(verificationProjection.values());
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -46,6 +46,11 @@ import http from 'node:http';
 import { attachWebSocketServer } from './websocket/server.js';
 import { createWebSocketRouter } from './routes/websocket.js';
 import { complianceRouter } from './routes/compliance.js';
+import { receiptsRouter } from './routes/receipts.js';
+import { eventsRouter } from './routes/events.js';
+import { threatDetectionRouter } from './routes/threat-detection.js';
+import { serviceMeshRouter } from './routes/service-mesh.js';
+import './events/projections.js';
 
 // Validate environment variables at startup
 validateEnv();
@@ -281,6 +286,18 @@ app.use('/api/v1/hedging', hedgingRouter);
 
 // SOC 2 / compliance evidence endpoints
 app.use('/api/v1/compliance', complianceRouter);
+
+// Payment receipt NFTs
+app.use('/api/v1/receipts', receiptsRouter);
+
+// Event-driven architecture — event store, CQRS projections
+app.use('/api/v1/events', eventsRouter);
+
+// Advanced threat detection with behavioral analysis
+app.use('/api/v1/threat-detection', threatDetectionRouter);
+
+// Microservices service mesh — registry, discovery, circuit breakers
+app.use('/api/v1/service-mesh', serviceMeshRouter);
 
 app.use('/api', (req: Request, res: Response, next: NextFunction) => {
   if (req.path.startsWith('/v1/')) {

--- a/backend/src/middleware/circuit-breaker.ts
+++ b/backend/src/middleware/circuit-breaker.ts
@@ -1,0 +1,135 @@
+import type { NextFunction, Request, Response } from 'express';
+
+type CircuitState = 'closed' | 'open' | 'half_open';
+
+interface CircuitBreakerConfig {
+  failureThreshold: number;
+  successThreshold: number;
+  timeoutMs: number;
+  halfOpenMaxCalls: number;
+}
+
+interface CircuitBreakerState {
+  state: CircuitState;
+  failures: number;
+  successes: number;
+  halfOpenCalls: number;
+  lastFailureAt?: number;
+  openedAt?: number;
+}
+
+const DEFAULT_CONFIG: CircuitBreakerConfig = {
+  failureThreshold: 5,
+  successThreshold: 2,
+  timeoutMs: 60_000,
+  halfOpenMaxCalls: 3,
+};
+
+const circuits = new Map<string, CircuitBreakerState>();
+
+function getOrCreate(name: string): CircuitBreakerState {
+  const existing = circuits.get(name);
+  if (existing) return existing;
+  const state: CircuitBreakerState = { state: 'closed', failures: 0, successes: 0, halfOpenCalls: 0 };
+  circuits.set(name, state);
+  return state;
+}
+
+function onSuccess(name: string, config: CircuitBreakerConfig): void {
+  const cb = getOrCreate(name);
+  if (cb.state === 'half_open') {
+    cb.successes += 1;
+    if (cb.successes >= config.successThreshold) {
+      cb.state = 'closed';
+      cb.failures = 0;
+      cb.successes = 0;
+      cb.halfOpenCalls = 0;
+    }
+  } else if (cb.state === 'closed') {
+    cb.failures = Math.max(0, cb.failures - 1);
+  }
+  circuits.set(name, cb);
+}
+
+function onFailure(name: string, config: CircuitBreakerConfig): void {
+  const cb = getOrCreate(name);
+  cb.failures += 1;
+  cb.lastFailureAt = Date.now();
+
+  if (cb.state === 'half_open' || cb.failures >= config.failureThreshold) {
+    cb.state = 'open';
+    cb.openedAt = Date.now();
+    cb.halfOpenCalls = 0;
+    cb.successes = 0;
+  }
+
+  circuits.set(name, cb);
+}
+
+function shouldAllow(name: string, config: CircuitBreakerConfig): boolean {
+  const cb = getOrCreate(name);
+
+  if (cb.state === 'closed') return true;
+
+  if (cb.state === 'open') {
+    const elapsed = Date.now() - (cb.openedAt ?? 0);
+    if (elapsed >= config.timeoutMs) {
+      cb.state = 'half_open';
+      cb.successes = 0;
+      cb.halfOpenCalls = 0;
+      circuits.set(name, cb);
+      return true;
+    }
+    return false;
+  }
+
+  // half_open: allow limited calls
+  if (cb.halfOpenCalls < config.halfOpenMaxCalls) {
+    cb.halfOpenCalls += 1;
+    circuits.set(name, cb);
+    return true;
+  }
+
+  return false;
+}
+
+export function circuitBreaker(name: string, config: Partial<CircuitBreakerConfig> = {}) {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!shouldAllow(name, cfg)) {
+      res.status(503).json({
+        error: {
+          code: 'CIRCUIT_OPEN',
+          message: `Service ${name} is temporarily unavailable. Circuit breaker is open.`,
+          status: 503,
+        },
+      });
+      return;
+    }
+
+    const originalJson = res.json.bind(res);
+    res.json = (body: unknown) => {
+      if (res.statusCode >= 500) {
+        onFailure(name, cfg);
+      } else {
+        onSuccess(name, cfg);
+      }
+      return originalJson(body);
+    };
+
+    next();
+  };
+}
+
+export function getCircuitState(name: string): CircuitBreakerState & { name: string } {
+  return { name, ...getOrCreate(name) };
+}
+
+export function getAllCircuits(): Array<CircuitBreakerState & { name: string }> {
+  return Array.from(circuits.entries()).map(([name, state]) => ({ name, ...state }));
+}
+
+export function resetCircuit(name: string): void {
+  circuits.set(name, { state: 'closed', failures: 0, successes: 0, halfOpenCalls: 0 });
+}

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -1,0 +1,174 @@
+import { Router } from 'express';
+import { AppError, asyncHandler } from '../middleware/errorHandler.js';
+import { cacheControl, CacheTTL } from '../middleware/cache.js';
+import {
+  appendEvent,
+  loadEvents,
+  loadSnapshot,
+  getAllEvents,
+  getEventsByType,
+  getAllStreams,
+  getEventStats,
+} from '../events/event-store.js';
+import {
+  getAllPayments,
+  getAllProjects,
+  getAllVerifications,
+  getPaymentReadModel,
+  getProjectReadModel,
+  getVerificationReadModel,
+} from '../events/projections.js';
+import { publish } from '../events/event-bus.js';
+import type { DomainEventType } from '../events/event-types.js';
+
+export const eventsRouter = Router();
+
+eventsRouter.post(
+  '/append',
+  asyncHandler(async (req, res) => {
+    const { aggregateType, aggregateId, type, payload, metadata, expectedVersion } = req.body as {
+      aggregateType?: string;
+      aggregateId?: string;
+      type?: string;
+      payload?: unknown;
+      metadata?: Record<string, string>;
+      expectedVersion?: number;
+    };
+
+    if (!aggregateType || !aggregateId || !type) {
+      throw new AppError(400, 'aggregateType, aggregateId and type are required', 'VALIDATION_ERROR');
+    }
+
+    try {
+      const stored = appendEvent(
+        aggregateType,
+        aggregateId,
+        type as DomainEventType,
+        payload ?? {},
+        metadata ?? {},
+        { expectedVersion }
+      );
+      await publish(stored);
+      res.status(201).json(stored);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Append failed';
+      throw new AppError(409, msg, 'CONCURRENCY_CONFLICT');
+    }
+  })
+);
+
+eventsRouter.get(
+  '/streams',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (_req, res) => {
+    res.json(getAllStreams());
+  })
+);
+
+eventsRouter.get(
+  '/streams/:aggregateType/:aggregateId',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const { aggregateType, aggregateId } = req.params;
+    const fromVersion = parseInt(req.query.fromVersion as string) || 0;
+    const events = loadEvents(aggregateType, aggregateId, fromVersion);
+    res.json({ aggregateType, aggregateId, events, count: events.length });
+  })
+);
+
+eventsRouter.get(
+  '/streams/:aggregateType/:aggregateId/snapshot',
+  asyncHandler(async (req, res) => {
+    const { aggregateType, aggregateId } = req.params;
+    const { asOf } = req.query as { asOf?: string };
+
+    if (!asOf) {
+      throw new AppError(400, 'asOf query parameter is required (ISO 8601)', 'VALIDATION_ERROR');
+    }
+
+    const events = loadSnapshot({ aggregateType, aggregateId, asOf });
+    res.json({ aggregateType, aggregateId, asOf, events, count: events.length });
+  })
+);
+
+eventsRouter.get(
+  '/global',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const fromSequence = parseInt(req.query.fromSequence as string) || 0;
+    const events = getAllEvents(fromSequence);
+    res.json({ events, count: events.length });
+  })
+);
+
+eventsRouter.get(
+  '/by-type/:type',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const events = getEventsByType(req.params.type as DomainEventType);
+    res.json({ type: req.params.type, events, count: events.length });
+  })
+);
+
+eventsRouter.get(
+  '/stats',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (_req, res) => {
+    res.json(getEventStats());
+  })
+);
+
+// CQRS read model endpoints
+eventsRouter.get(
+  '/projections/payments',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (_req, res) => {
+    res.json(getAllPayments());
+  })
+);
+
+eventsRouter.get(
+  '/projections/payments/:paymentId',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const model = getPaymentReadModel(req.params.paymentId);
+    if (!model) throw new AppError(404, 'Payment projection not found', 'NOT_FOUND');
+    res.json(model);
+  })
+);
+
+eventsRouter.get(
+  '/projections/projects',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (_req, res) => {
+    res.json(getAllProjects());
+  })
+);
+
+eventsRouter.get(
+  '/projections/projects/:projectId',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const model = getProjectReadModel(req.params.projectId);
+    if (!model) throw new AppError(404, 'Project projection not found', 'NOT_FOUND');
+    res.json(model);
+  })
+);
+
+eventsRouter.get(
+  '/projections/verifications',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (_req, res) => {
+    res.json(getAllVerifications());
+  })
+);
+
+eventsRouter.get(
+  '/projections/verifications/:verificationId',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const model = getVerificationReadModel(req.params.verificationId);
+    if (!model) throw new AppError(404, 'Verification projection not found', 'NOT_FOUND');
+    res.json(model);
+  })
+);

--- a/backend/src/routes/receipts.ts
+++ b/backend/src/routes/receipts.ts
@@ -1,0 +1,130 @@
+import { Router } from 'express';
+import { validate } from '../middleware/validate.js';
+import { AppError, asyncHandler } from '../middleware/errorHandler.js';
+import { idempotency } from '../middleware/idempotency.js';
+import { cacheControl, CacheTTL } from '../middleware/cache.js';
+import {
+  mintReceipt,
+  batchMintReceipts,
+  transferReceipt,
+  burnReceipt,
+  getReceiptByTokenId,
+  getReceiptByPaymentId,
+  getReceiptByTxHash,
+  getReceiptsByWallet,
+  getAllReceipts,
+} from '../services/receipts.js';
+import {
+  mintReceiptSchema,
+  batchMintReceiptSchema,
+  transferReceiptSchema,
+} from '../schemas/receipts.js';
+
+export const receiptsRouter = Router();
+
+receiptsRouter.post(
+  '/mint',
+  idempotency(),
+  validate(mintReceiptSchema),
+  asyncHandler(async (req, res) => {
+    const receipt = mintReceipt(req.body);
+    res.status(201).json(receipt);
+  })
+);
+
+receiptsRouter.post(
+  '/mint/batch',
+  idempotency(),
+  validate(batchMintReceiptSchema),
+  asyncHandler(async (req, res) => {
+    const results = batchMintReceipts({ receipts: req.body.receipts });
+    res.status(201).json({ receipts: results, count: results.length });
+  })
+);
+
+receiptsRouter.patch(
+  '/:tokenId/transfer',
+  validate(transferReceiptSchema),
+  asyncHandler(async (req, res) => {
+    const { tokenId } = req.params;
+    const { newOwner } = req.body as { newOwner: string };
+    try {
+      const receipt = transferReceipt(tokenId, newOwner);
+      res.json(receipt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Transfer failed';
+      throw new AppError(400, msg, 'TRANSFER_FAILED');
+    }
+  })
+);
+
+receiptsRouter.delete(
+  '/:tokenId/burn',
+  asyncHandler(async (req, res) => {
+    const { tokenId } = req.params;
+    try {
+      const receipt = burnReceipt(tokenId);
+      res.json({ message: 'Receipt burned', receipt });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Burn failed';
+      throw new AppError(400, msg, 'BURN_FAILED');
+    }
+  })
+);
+
+receiptsRouter.get(
+  '/',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const includeBurned = req.query.includeBurned === 'true';
+    res.json(getAllReceipts(includeBurned));
+  })
+);
+
+receiptsRouter.get(
+  '/by-payment/:paymentId',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const receipt = getReceiptByPaymentId(req.params.paymentId);
+    if (!receipt) throw new AppError(404, 'Receipt not found', 'NOT_FOUND');
+    res.json(receipt);
+  })
+);
+
+receiptsRouter.get(
+  '/by-tx/:txHash',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const receipt = getReceiptByTxHash(req.params.txHash);
+    if (!receipt) throw new AppError(404, 'Receipt not found', 'NOT_FOUND');
+    res.json(receipt);
+  })
+);
+
+receiptsRouter.get(
+  '/by-wallet/:walletAddress',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    res.json(getReceiptsByWallet(req.params.walletAddress));
+  })
+);
+
+receiptsRouter.get(
+  '/:tokenId',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const receipt = getReceiptByTokenId(req.params.tokenId);
+    if (!receipt) throw new AppError(404, 'Receipt not found', 'NOT_FOUND');
+    res.json(receipt);
+  })
+);
+
+receiptsRouter.get(
+  '/:tokenId/metadata',
+  cacheControl({ maxAge: CacheTTL.LONG }),
+  asyncHandler(async (req, res) => {
+    const receipt = getReceiptByTokenId(req.params.tokenId);
+    if (!receipt) throw new AppError(404, 'Receipt not found', 'NOT_FOUND');
+    res.json(receipt.metadata);
+  })
+);

--- a/backend/src/routes/service-mesh.ts
+++ b/backend/src/routes/service-mesh.ts
@@ -1,0 +1,162 @@
+import { Router } from 'express';
+import { AppError, asyncHandler } from '../middleware/errorHandler.js';
+import { cacheControl, CacheTTL } from '../middleware/cache.js';
+import {
+  registerService,
+  deregisterService,
+  heartbeat,
+  updateServiceStatus,
+  getService,
+  getServiceEndpoint,
+  resolveInstance,
+  getAllServices,
+  pruneStaleInstances,
+  getRegistryStats,
+} from '../services/service-registry.js';
+import {
+  getCircuitState,
+  getAllCircuits,
+  resetCircuit,
+} from '../middleware/circuit-breaker.js';
+import type { ServiceStatus } from '../services/service-registry.js';
+
+export const serviceMeshRouter = Router();
+
+// Service Registry
+serviceMeshRouter.post(
+  '/registry/register',
+  asyncHandler(async (req, res) => {
+    const { name, version, host, port, protocol, metadata, ttlSeconds } = req.body as {
+      name?: string;
+      version?: string;
+      host?: string;
+      port?: number;
+      protocol?: 'http' | 'grpc';
+      metadata?: Record<string, string>;
+      ttlSeconds?: number;
+    };
+
+    if (!name || !host || !port) {
+      throw new AppError(400, 'name, host and port are required', 'VALIDATION_ERROR');
+    }
+
+    const instance = registerService({
+      name,
+      version: version ?? '1.0.0',
+      host,
+      port,
+      protocol: protocol ?? 'http',
+      status: 'healthy',
+      metadata: metadata ?? {},
+      ttlSeconds: ttlSeconds ?? 30,
+    });
+
+    res.status(201).json(instance);
+  })
+);
+
+serviceMeshRouter.delete(
+  '/registry/:instanceId',
+  asyncHandler(async (req, res) => {
+    const deregistered = deregisterService(req.params.instanceId);
+    if (!deregistered) throw new AppError(404, 'Service instance not found', 'NOT_FOUND');
+    res.json({ message: 'Service deregistered', instanceId: req.params.instanceId });
+  })
+);
+
+serviceMeshRouter.post(
+  '/registry/:instanceId/heartbeat',
+  asyncHandler(async (req, res) => {
+    const instance = heartbeat(req.params.instanceId);
+    if (!instance) throw new AppError(404, 'Service instance not found', 'NOT_FOUND');
+    res.json(instance);
+  })
+);
+
+serviceMeshRouter.patch(
+  '/registry/:instanceId/status',
+  asyncHandler(async (req, res) => {
+    const { status } = req.body as { status?: ServiceStatus };
+    if (!status) throw new AppError(400, 'status is required', 'VALIDATION_ERROR');
+
+    const instance = updateServiceStatus(req.params.instanceId, status);
+    if (!instance) throw new AppError(404, 'Service instance not found', 'NOT_FOUND');
+    res.json(instance);
+  })
+);
+
+serviceMeshRouter.get(
+  '/registry',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (_req, res) => {
+    res.json(getAllServices());
+  })
+);
+
+serviceMeshRouter.get(
+  '/registry/stats',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (_req, res) => {
+    res.json(getRegistryStats());
+  })
+);
+
+serviceMeshRouter.get(
+  '/registry/:instanceId',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const instance = getService(req.params.instanceId);
+    if (!instance) throw new AppError(404, 'Service instance not found', 'NOT_FOUND');
+    res.json(instance);
+  })
+);
+
+serviceMeshRouter.get(
+  '/discover/:serviceName',
+  asyncHandler(async (req, res) => {
+    const endpoint = getServiceEndpoint(req.params.serviceName);
+    res.json(endpoint);
+  })
+);
+
+serviceMeshRouter.get(
+  '/resolve/:serviceName',
+  asyncHandler(async (req, res) => {
+    const instance = resolveInstance(req.params.serviceName);
+    if (!instance) throw new AppError(503, `No healthy instances for service ${req.params.serviceName}`, 'SERVICE_UNAVAILABLE');
+    res.json(instance);
+  })
+);
+
+serviceMeshRouter.post(
+  '/registry/prune',
+  asyncHandler(async (_req, res) => {
+    const pruned = pruneStaleInstances();
+    res.json({ pruned, message: `${pruned} stale instances marked unhealthy` });
+  })
+);
+
+// Circuit Breakers
+serviceMeshRouter.get(
+  '/circuits',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (_req, res) => {
+    res.json(getAllCircuits());
+  })
+);
+
+serviceMeshRouter.get(
+  '/circuits/:name',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    res.json(getCircuitState(req.params.name));
+  })
+);
+
+serviceMeshRouter.post(
+  '/circuits/:name/reset',
+  asyncHandler(async (req, res) => {
+    resetCircuit(req.params.name);
+    res.json({ message: `Circuit ${req.params.name} reset to closed state` });
+  })
+);

--- a/backend/src/routes/threat-detection.ts
+++ b/backend/src/routes/threat-detection.ts
@@ -1,0 +1,150 @@
+import { Router } from 'express';
+import { AppError, asyncHandler } from '../middleware/errorHandler.js';
+import { cacheControl, CacheTTL } from '../middleware/cache.js';
+import {
+  recordBehaviorEvent,
+  getBaseline,
+  getAllThreats,
+  getThreatById,
+  getThreatsByUser,
+  getOpenThreats,
+  updateThreatStatus,
+  unlockAccount,
+  isAccountLocked,
+  getThreatStats,
+  refreshThreatIntel,
+  getThreatIntelStatus,
+} from '../services/threat-detection.js';
+import type { ThreatStatus } from '../types/threat-detection.js';
+
+export const threatDetectionRouter = Router();
+
+threatDetectionRouter.post(
+  '/events',
+  asyncHandler(async (req, res) => {
+    const { userId, action, ipAddress, userAgent, endpoint, method, statusCode, durationMs, metadata } =
+      req.body as {
+        userId?: string;
+        action?: string;
+        ipAddress?: string;
+        userAgent?: string;
+        endpoint?: string;
+        method?: string;
+        statusCode?: number;
+        durationMs?: number;
+        metadata?: Record<string, unknown>;
+      };
+
+    if (!userId || !action || !ipAddress || !endpoint || !method) {
+      throw new AppError(400, 'userId, action, ipAddress, endpoint and method are required', 'VALIDATION_ERROR');
+    }
+
+    const score = recordBehaviorEvent({
+      userId,
+      action,
+      ipAddress,
+      userAgent: userAgent ?? 'unknown',
+      endpoint,
+      method,
+      statusCode: statusCode ?? 200,
+      durationMs: durationMs ?? 0,
+      timestamp: new Date().toISOString(),
+      metadata,
+    });
+
+    res.json(score);
+  })
+);
+
+threatDetectionRouter.get(
+  '/stats',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (_req, res) => {
+    res.json(getThreatStats());
+  })
+);
+
+threatDetectionRouter.get(
+  '/threats',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const threats = req.query.open === 'true' ? getOpenThreats() : getAllThreats();
+    res.json({ threats, count: threats.length });
+  })
+);
+
+threatDetectionRouter.get(
+  '/threats/:id',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const threat = getThreatById(req.params.id);
+    if (!threat) throw new AppError(404, 'Threat not found', 'NOT_FOUND');
+    res.json(threat);
+  })
+);
+
+threatDetectionRouter.patch(
+  '/threats/:id/status',
+  asyncHandler(async (req, res) => {
+    const { status, resolution } = req.body as { status?: ThreatStatus; resolution?: string };
+    if (!status) throw new AppError(400, 'status is required', 'VALIDATION_ERROR');
+
+    const updated = updateThreatStatus(req.params.id, status, resolution);
+    if (!updated) throw new AppError(404, 'Threat not found', 'NOT_FOUND');
+    res.json(updated);
+  })
+);
+
+threatDetectionRouter.get(
+  '/users/:userId/threats',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const threats = getThreatsByUser(req.params.userId);
+    res.json({ userId: req.params.userId, threats, count: threats.length });
+  })
+);
+
+threatDetectionRouter.get(
+  '/users/:userId/baseline',
+  cacheControl({ maxAge: CacheTTL.SHORT }),
+  asyncHandler(async (req, res) => {
+    const baseline = getBaseline(req.params.userId);
+    if (!baseline) throw new AppError(404, 'No baseline found for user', 'NOT_FOUND');
+    res.json(baseline);
+  })
+);
+
+threatDetectionRouter.get(
+  '/users/:userId/locked',
+  asyncHandler(async (req, res) => {
+    res.json({ userId: req.params.userId, locked: isAccountLocked(req.params.userId) });
+  })
+);
+
+threatDetectionRouter.post(
+  '/users/:userId/unlock',
+  asyncHandler(async (req, res) => {
+    const unlocked = unlockAccount(req.params.userId);
+    res.json({ userId: req.params.userId, unlocked });
+  })
+);
+
+threatDetectionRouter.get(
+  '/intel/status',
+  cacheControl({ maxAge: CacheTTL.LONG }),
+  asyncHandler(async (_req, res) => {
+    res.json(getThreatIntelStatus());
+  })
+);
+
+threatDetectionRouter.post(
+  '/intel/refresh',
+  asyncHandler(async (req, res) => {
+    const { maliciousIps } = req.body as { maliciousIps?: string[] };
+    if (!Array.isArray(maliciousIps)) {
+      throw new AppError(400, 'maliciousIps array is required', 'VALIDATION_ERROR');
+    }
+    refreshThreatIntel(maliciousIps);
+    res.json({ message: 'Threat intel refreshed', ...getThreatIntelStatus() });
+  })
+);

--- a/backend/src/schemas/receipts.ts
+++ b/backend/src/schemas/receipts.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const mintReceiptSchema = z.object({
+  paymentId: z.string().min(1, 'Payment ID is required'),
+  transactionHash: z.string().min(1, 'Transaction hash is required'),
+  sender: z.string().min(1, 'Sender address is required'),
+  recipient: z.string().min(1, 'Recipient address is required'),
+  amount: z.number().positive('Amount must be positive'),
+  asset: z.string().min(1, 'Asset is required'),
+});
+
+export const batchMintReceiptSchema = z.object({
+  receipts: z.array(mintReceiptSchema).min(1, 'At least one receipt is required').max(100),
+});
+
+export const transferReceiptSchema = z.object({
+  newOwner: z.string().min(1, 'New owner address is required'),
+});

--- a/backend/src/services/receipts.ts
+++ b/backend/src/services/receipts.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from 'node:crypto';
+
+export interface ReceiptNFT {
+  id: string;
+  tokenId: string;
+  paymentId: string;
+  transactionHash: string;
+  sender: string;
+  recipient: string;
+  amount: number;
+  asset: string;
+  mintedAt: string;
+  owner: string;
+  burned: boolean;
+  burnedAt?: string;
+  metadata: ReceiptMetadata;
+}
+
+export interface ReceiptMetadata {
+  name: string;
+  description: string;
+  image: string;
+  attributes: Array<{ trait_type: string; value: string | number }>;
+  external_url?: string;
+}
+
+interface MintReceiptInput {
+  paymentId: string;
+  transactionHash: string;
+  sender: string;
+  recipient: string;
+  amount: number;
+  asset: string;
+}
+
+interface BatchMintInput {
+  receipts: MintReceiptInput[];
+}
+
+const receipts = new Map<string, ReceiptNFT>();
+const paymentIndex = new Map<string, string>();
+const walletIndex = new Map<string, Set<string>>();
+const txHashIndex = new Map<string, string>();
+
+let tokenCounter = 0;
+
+function nextTokenId(): string {
+  tokenCounter += 1;
+  return `RCPT-${String(tokenCounter).padStart(8, '0')}`;
+}
+
+function buildMetadata(receipt: Omit<ReceiptNFT, 'metadata'>): ReceiptMetadata {
+  return {
+    name: `AgenticPay Receipt #${receipt.tokenId}`,
+    description: `Verified payment receipt for transaction ${receipt.transactionHash}`,
+    image: `https://receipts.agenticpay.io/nft/${receipt.tokenId}.png`,
+    external_url: `https://agenticpay.io/receipts/${receipt.tokenId}`,
+    attributes: [
+      { trait_type: 'Payment ID', value: receipt.paymentId },
+      { trait_type: 'Transaction Hash', value: receipt.transactionHash },
+      { trait_type: 'Sender', value: receipt.sender },
+      { trait_type: 'Recipient', value: receipt.recipient },
+      { trait_type: 'Amount', value: receipt.amount },
+      { trait_type: 'Asset', value: receipt.asset },
+      { trait_type: 'Minted At', value: receipt.mintedAt },
+    ],
+  };
+}
+
+function indexByWallet(walletAddress: string, tokenId: string): void {
+  const existing = walletIndex.get(walletAddress) ?? new Set<string>();
+  existing.add(tokenId);
+  walletIndex.set(walletAddress, existing);
+}
+
+function removeFromWalletIndex(walletAddress: string, tokenId: string): void {
+  const existing = walletIndex.get(walletAddress);
+  if (existing) {
+    existing.delete(tokenId);
+  }
+}
+
+export function mintReceipt(input: MintReceiptInput): ReceiptNFT {
+  if (paymentIndex.has(input.paymentId)) {
+    const existing = receipts.get(paymentIndex.get(input.paymentId)!);
+    if (existing && !existing.burned) {
+      throw new Error(`Receipt already exists for payment ${input.paymentId}`);
+    }
+  }
+
+  const tokenId = nextTokenId();
+  const now = new Date().toISOString();
+
+  const base = {
+    id: randomUUID(),
+    tokenId,
+    paymentId: input.paymentId,
+    transactionHash: input.transactionHash,
+    sender: input.sender,
+    recipient: input.recipient,
+    amount: input.amount,
+    asset: input.asset,
+    mintedAt: now,
+    owner: input.recipient,
+    burned: false,
+  };
+
+  const receipt: ReceiptNFT = { ...base, metadata: buildMetadata(base) };
+
+  receipts.set(tokenId, receipt);
+  paymentIndex.set(input.paymentId, tokenId);
+  txHashIndex.set(input.transactionHash, tokenId);
+  indexByWallet(input.recipient, tokenId);
+
+  return receipt;
+}
+
+export function batchMintReceipts(input: BatchMintInput): ReceiptNFT[] {
+  return input.receipts.map(mintReceipt);
+}
+
+export function transferReceipt(tokenId: string, newOwner: string): ReceiptNFT {
+  const receipt = receipts.get(tokenId);
+  if (!receipt) throw new Error(`Receipt ${tokenId} not found`);
+  if (receipt.burned) throw new Error(`Receipt ${tokenId} is burned and cannot be transferred`);
+
+  removeFromWalletIndex(receipt.owner, tokenId);
+  receipt.owner = newOwner;
+  indexByWallet(newOwner, tokenId);
+  receipts.set(tokenId, receipt);
+
+  return receipt;
+}
+
+export function burnReceipt(tokenId: string): ReceiptNFT {
+  const receipt = receipts.get(tokenId);
+  if (!receipt) throw new Error(`Receipt ${tokenId} not found`);
+  if (receipt.burned) throw new Error(`Receipt ${tokenId} is already burned`);
+
+  receipt.burned = true;
+  receipt.burnedAt = new Date().toISOString();
+  removeFromWalletIndex(receipt.owner, tokenId);
+  receipts.set(tokenId, receipt);
+
+  return receipt;
+}
+
+export function getReceiptByTokenId(tokenId: string): ReceiptNFT | undefined {
+  return receipts.get(tokenId);
+}
+
+export function getReceiptByPaymentId(paymentId: string): ReceiptNFT | undefined {
+  const tokenId = paymentIndex.get(paymentId);
+  return tokenId ? receipts.get(tokenId) : undefined;
+}
+
+export function getReceiptByTxHash(txHash: string): ReceiptNFT | undefined {
+  const tokenId = txHashIndex.get(txHash);
+  return tokenId ? receipts.get(tokenId) : undefined;
+}
+
+export function getReceiptsByWallet(walletAddress: string): ReceiptNFT[] {
+  const tokenIds = walletIndex.get(walletAddress) ?? new Set<string>();
+  return Array.from(tokenIds)
+    .map((id) => receipts.get(id))
+    .filter((r): r is ReceiptNFT => r !== undefined);
+}
+
+export function getAllReceipts(includesBurned = false): ReceiptNFT[] {
+  const all = Array.from(receipts.values());
+  return includesBurned ? all : all.filter((r) => !r.burned);
+}

--- a/backend/src/services/service-registry.ts
+++ b/backend/src/services/service-registry.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'node:crypto';
+
+export type ServiceStatus = 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+
+export interface ServiceInstance {
+  id: string;
+  name: string;
+  version: string;
+  host: string;
+  port: number;
+  protocol: 'http' | 'grpc';
+  status: ServiceStatus;
+  metadata: Record<string, string>;
+  registeredAt: string;
+  lastHeartbeatAt: string;
+  ttlSeconds: number;
+}
+
+export interface ServiceEndpoint {
+  name: string;
+  instances: ServiceInstance[];
+  loadBalancingPolicy: 'round_robin' | 'least_connections' | 'random';
+}
+
+const registry = new Map<string, ServiceInstance>();
+const serviceIndex = new Map<string, Set<string>>();
+let rrCounters = new Map<string, number>();
+
+const HEARTBEAT_TIMEOUT_MS = 30_000;
+
+export function registerService(input: Omit<ServiceInstance, 'id' | 'registeredAt' | 'lastHeartbeatAt'>): ServiceInstance {
+  const instance: ServiceInstance = {
+    ...input,
+    id: randomUUID(),
+    registeredAt: new Date().toISOString(),
+    lastHeartbeatAt: new Date().toISOString(),
+  };
+
+  registry.set(instance.id, instance);
+  const ids = serviceIndex.get(instance.name) ?? new Set<string>();
+  ids.add(instance.id);
+  serviceIndex.set(instance.name, ids);
+
+  return instance;
+}
+
+export function deregisterService(instanceId: string): boolean {
+  const instance = registry.get(instanceId);
+  if (!instance) return false;
+
+  registry.delete(instanceId);
+  const ids = serviceIndex.get(instance.name);
+  if (ids) ids.delete(instanceId);
+
+  return true;
+}
+
+export function heartbeat(instanceId: string): ServiceInstance | undefined {
+  const instance = registry.get(instanceId);
+  if (!instance) return undefined;
+
+  instance.lastHeartbeatAt = new Date().toISOString();
+  instance.status = 'healthy';
+  registry.set(instanceId, instance);
+  return instance;
+}
+
+export function updateServiceStatus(instanceId: string, status: ServiceStatus): ServiceInstance | undefined {
+  const instance = registry.get(instanceId);
+  if (!instance) return undefined;
+  instance.status = status;
+  registry.set(instanceId, instance);
+  return instance;
+}
+
+export function getService(instanceId: string): ServiceInstance | undefined {
+  return registry.get(instanceId);
+}
+
+export function getServiceEndpoint(name: string): ServiceEndpoint {
+  const ids = serviceIndex.get(name) ?? new Set<string>();
+  const instances = Array.from(ids)
+    .map((id) => registry.get(id))
+    .filter((i): i is ServiceInstance => i !== undefined);
+
+  return { name, instances, loadBalancingPolicy: 'round_robin' };
+}
+
+export function resolveInstance(name: string): ServiceInstance | undefined {
+  const endpoint = getServiceEndpoint(name);
+  const healthy = endpoint.instances.filter((i) => i.status === 'healthy' || i.status === 'degraded');
+  if (healthy.length === 0) return undefined;
+
+  const counter = rrCounters.get(name) ?? 0;
+  const selected = healthy[counter % healthy.length];
+  rrCounters.set(name, counter + 1);
+  return selected;
+}
+
+export function getAllServices(): ServiceInstance[] {
+  return Array.from(registry.values());
+}
+
+export function pruneStaleInstances(): number {
+  const cutoff = Date.now() - HEARTBEAT_TIMEOUT_MS;
+  let pruned = 0;
+
+  for (const instance of registry.values()) {
+    if (new Date(instance.lastHeartbeatAt).getTime() < cutoff) {
+      instance.status = 'unhealthy';
+      registry.set(instance.id, instance);
+      pruned += 1;
+    }
+  }
+
+  return pruned;
+}
+
+export function getRegistryStats() {
+  const all = Array.from(registry.values());
+  return {
+    total: all.length,
+    healthy: all.filter((i) => i.status === 'healthy').length,
+    degraded: all.filter((i) => i.status === 'degraded').length,
+    unhealthy: all.filter((i) => i.status === 'unhealthy').length,
+    services: Array.from(serviceIndex.keys()),
+  };
+}

--- a/backend/src/services/threat-detection.ts
+++ b/backend/src/services/threat-detection.ts
@@ -1,0 +1,285 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  AnomalyFactor,
+  AnomalyScore,
+  BehaviorEvent,
+  ThreatEvent,
+  ThreatIntelFeed,
+  ThreatSeverity,
+  ThreatStatus,
+  UserBaseline,
+} from '../types/threat-detection.js';
+
+const baselines = new Map<string, UserBaseline>();
+const behaviorHistory = new Map<string, BehaviorEvent[]>();
+const threats = new Map<string, ThreatEvent>();
+const lockedAccounts = new Set<string>();
+
+const BASELINE_WINDOW_HOURS = 168; // 7 days
+const HIGH_SCORE_THRESHOLD = 75;
+const CRITICAL_SCORE_THRESHOLD = 90;
+const MAX_HISTORY_PER_USER = 1000;
+
+const threatIntel: ThreatIntelFeed = {
+  maliciousIps: new Set([
+    '192.0.2.0',
+    '198.51.100.0',
+    '203.0.113.0',
+  ]),
+  suspiciousPatterns: [
+    /sqlmap/i,
+    /nikto/i,
+    /masscan/i,
+    /nmap/i,
+    /hydra/i,
+  ],
+  lastRefreshed: new Date().toISOString(),
+};
+
+export function recordBehaviorEvent(event: BehaviorEvent): AnomalyScore {
+  const history = behaviorHistory.get(event.userId) ?? [];
+  history.push(event);
+  if (history.length > MAX_HISTORY_PER_USER) {
+    history.splice(0, history.length - MAX_HISTORY_PER_USER);
+  }
+  behaviorHistory.set(event.userId, history);
+
+  updateBaseline(event.userId, history);
+  const score = computeAnomalyScore(event, history);
+
+  if (score.score >= HIGH_SCORE_THRESHOLD) {
+    recordThreat(event, score);
+  }
+
+  return score;
+}
+
+function updateBaseline(userId: string, history: BehaviorEvent[]): void {
+  const cutoff = Date.now() - BASELINE_WINDOW_HOURS * 60 * 60 * 1000;
+  const recent = history.filter((e) => new Date(e.timestamp).getTime() >= cutoff);
+
+  if (recent.length < 5) return;
+
+  const ipCounts = new Map<string, number>();
+  const uaCounts = new Map<string, number>();
+  const endpointCounts = new Map<string, number>();
+  const hourCounts = new Map<number, number>();
+  let totalDuration = 0;
+
+  for (const e of recent) {
+    ipCounts.set(e.ipAddress, (ipCounts.get(e.ipAddress) ?? 0) + 1);
+    uaCounts.set(e.userAgent, (uaCounts.get(e.userAgent) ?? 0) + 1);
+    endpointCounts.set(e.endpoint, (endpointCounts.get(e.endpoint) ?? 0) + 1);
+    const hour = new Date(e.timestamp).getHours();
+    hourCounts.set(hour, (hourCounts.get(hour) ?? 0) + 1);
+    totalDuration += e.durationMs;
+  }
+
+  const topN = <K>(map: Map<K, number>, n: number): K[] =>
+    Array.from(map.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, n)
+      .map(([k]) => k);
+
+  const daySpan = Math.max(1, BASELINE_WINDOW_HOURS / 24);
+  const hourSpan = Math.max(1, BASELINE_WINDOW_HOURS);
+
+  baselines.set(userId, {
+    userId,
+    avgRequestsPerHour: recent.length / hourSpan,
+    avgRequestsPerDay: recent.length / daySpan,
+    commonIps: topN(ipCounts, 5),
+    commonUserAgents: topN(uaCounts, 3),
+    commonEndpoints: topN(endpointCounts, 10),
+    typicalHours: topN(hourCounts, 8),
+    avgResponseTimeMs: totalDuration / recent.length,
+    lastUpdated: new Date().toISOString(),
+    sampleCount: recent.length,
+  });
+}
+
+function computeAnomalyScore(event: BehaviorEvent, history: BehaviorEvent[]): AnomalyScore {
+  const factors: AnomalyFactor[] = [];
+  let score = 0;
+
+  const baseline = baselines.get(event.userId);
+
+  // Threat intel check
+  if (threatIntel.maliciousIps.has(event.ipAddress)) {
+    const contribution = 40;
+    score += contribution;
+    factors.push({ name: 'malicious_ip', contribution, details: `IP ${event.ipAddress} is in threat intel feed` });
+  }
+
+  // Suspicious user agent
+  for (const pattern of threatIntel.suspiciousPatterns) {
+    if (pattern.test(event.userAgent)) {
+      const contribution = 35;
+      score += contribution;
+      factors.push({ name: 'suspicious_user_agent', contribution, details: `User agent matches suspicious pattern: ${event.userAgent}` });
+      break;
+    }
+  }
+
+  if (baseline) {
+    // New IP not in baseline
+    if (!baseline.commonIps.includes(event.ipAddress)) {
+      const contribution = 15;
+      score += contribution;
+      factors.push({ name: 'new_ip_address', contribution, details: `IP ${event.ipAddress} not in established baseline` });
+    }
+
+    // Unusual hour
+    const hour = new Date(event.timestamp).getHours();
+    if (!baseline.typicalHours.includes(hour)) {
+      const contribution = 10;
+      score += contribution;
+      factors.push({ name: 'unusual_hour', contribution, details: `Activity at hour ${hour} outside typical pattern` });
+    }
+
+    // Response time anomaly (4x slower than baseline may indicate heavy probing)
+    if (event.durationMs > baseline.avgResponseTimeMs * 4 && baseline.avgResponseTimeMs > 0) {
+      const contribution = 10;
+      score += contribution;
+      factors.push({ name: 'response_time_anomaly', contribution, details: `Response time ${event.durationMs}ms is 4x above baseline` });
+    }
+
+    // High request rate in last hour
+    const hourAgo = Date.now() - 60 * 60 * 1000;
+    const recentCount = history.filter((e) => new Date(e.timestamp).getTime() >= hourAgo).length;
+    if (recentCount > baseline.avgRequestsPerHour * 5) {
+      const contribution = 20;
+      score += contribution;
+      factors.push({ name: 'request_rate_spike', contribution, details: `${recentCount} requests in last hour vs baseline ${Math.round(baseline.avgRequestsPerHour)}` });
+    }
+  }
+
+  // Repeated 4xx errors — scanning pattern
+  const recent5Min = history.filter(
+    (e) => Date.now() - new Date(e.timestamp).getTime() < 5 * 60 * 1000
+  );
+  const errorCount = recent5Min.filter((e) => e.statusCode >= 400 && e.statusCode < 500).length;
+  if (errorCount >= 10) {
+    const contribution = Math.min(25, errorCount);
+    score += contribution;
+    factors.push({ name: 'high_error_rate', contribution, details: `${errorCount} client errors in last 5 minutes` });
+  }
+
+  return {
+    userId: event.userId,
+    score: Math.min(100, score),
+    factors,
+    computedAt: new Date().toISOString(),
+  };
+}
+
+function severityFromScore(score: number): ThreatSeverity {
+  if (score >= CRITICAL_SCORE_THRESHOLD) return 'critical';
+  if (score >= HIGH_SCORE_THRESHOLD) return 'high';
+  if (score >= 50) return 'medium';
+  return 'low';
+}
+
+function recordThreat(event: BehaviorEvent, score: AnomalyScore): ThreatEvent {
+  const severity = severityFromScore(score.score);
+  const shouldLock = severity === 'critical';
+
+  if (shouldLock) {
+    lockedAccounts.add(event.userId);
+  }
+
+  const threat: ThreatEvent = {
+    id: randomUUID(),
+    userId: event.userId,
+    severity,
+    status: 'open',
+    anomalyScore: score.score,
+    factors: score.factors,
+    ipAddress: event.ipAddress,
+    detectedAt: new Date().toISOString(),
+    falsePositive: false,
+    accountLocked: shouldLock,
+  };
+
+  threats.set(threat.id, threat);
+  return threat;
+}
+
+export function getBaseline(userId: string): UserBaseline | undefined {
+  return baselines.get(userId);
+}
+
+export function getAllThreats(): ThreatEvent[] {
+  return Array.from(threats.values());
+}
+
+export function getThreatById(id: string): ThreatEvent | undefined {
+  return threats.get(id);
+}
+
+export function getThreatsByUser(userId: string): ThreatEvent[] {
+  return Array.from(threats.values()).filter((t) => t.userId === userId);
+}
+
+export function getOpenThreats(): ThreatEvent[] {
+  return Array.from(threats.values()).filter((t) => t.status === 'open' || t.status === 'investigating');
+}
+
+export function updateThreatStatus(
+  id: string,
+  status: ThreatStatus,
+  resolution?: string
+): ThreatEvent | undefined {
+  const threat = threats.get(id);
+  if (!threat) return undefined;
+
+  threat.status = status;
+  if (resolution) threat.resolution = resolution;
+  if (status === 'resolved' || status === 'false_positive') {
+    threat.resolvedAt = new Date().toISOString();
+    threat.falsePositive = status === 'false_positive';
+    lockedAccounts.delete(threat.userId);
+  }
+  threats.set(id, threat);
+  return threat;
+}
+
+export function unlockAccount(userId: string): boolean {
+  return lockedAccounts.delete(userId);
+}
+
+export function isAccountLocked(userId: string): boolean {
+  return lockedAccounts.has(userId);
+}
+
+export function getThreatStats() {
+  const all = Array.from(threats.values());
+  const bySeverity = { low: 0, medium: 0, high: 0, critical: 0 };
+  const byStatus = { open: 0, investigating: 0, resolved: 0, false_positive: 0 };
+
+  for (const t of all) {
+    bySeverity[t.severity] += 1;
+    byStatus[t.status] += 1;
+  }
+
+  return {
+    total: all.length,
+    bySeverity,
+    byStatus,
+    lockedAccounts: lockedAccounts.size,
+    trackedUsers: baselines.size,
+  };
+}
+
+export function refreshThreatIntel(maliciousIps: string[]): void {
+  threatIntel.maliciousIps = new Set(maliciousIps);
+  threatIntel.lastRefreshed = new Date().toISOString();
+}
+
+export function getThreatIntelStatus() {
+  return {
+    maliciousIpCount: threatIntel.maliciousIps.size,
+    patternCount: threatIntel.suspiciousPatterns.length,
+    lastRefreshed: threatIntel.lastRefreshed,
+  };
+}

--- a/backend/src/types/threat-detection.ts
+++ b/backend/src/types/threat-detection.ts
@@ -1,0 +1,62 @@
+export type ThreatSeverity = 'low' | 'medium' | 'high' | 'critical';
+export type ThreatStatus = 'open' | 'investigating' | 'resolved' | 'false_positive';
+
+export interface BehaviorEvent {
+  userId: string;
+  action: string;
+  ipAddress: string;
+  userAgent: string;
+  endpoint: string;
+  method: string;
+  statusCode: number;
+  durationMs: number;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UserBaseline {
+  userId: string;
+  avgRequestsPerHour: number;
+  avgRequestsPerDay: number;
+  commonIps: string[];
+  commonUserAgents: string[];
+  commonEndpoints: string[];
+  typicalHours: number[];
+  avgResponseTimeMs: number;
+  lastUpdated: string;
+  sampleCount: number;
+}
+
+export interface AnomalyScore {
+  userId: string;
+  score: number;
+  factors: AnomalyFactor[];
+  computedAt: string;
+}
+
+export interface AnomalyFactor {
+  name: string;
+  contribution: number;
+  details: string;
+}
+
+export interface ThreatEvent {
+  id: string;
+  userId: string;
+  severity: ThreatSeverity;
+  status: ThreatStatus;
+  anomalyScore: number;
+  factors: AnomalyFactor[];
+  ipAddress: string;
+  detectedAt: string;
+  resolvedAt?: string;
+  resolution?: string;
+  falsePositive: boolean;
+  accountLocked: boolean;
+}
+
+export interface ThreatIntelFeed {
+  maliciousIps: Set<string>;
+  suspiciousPatterns: RegExp[];
+  lastRefreshed: string;
+}


### PR DESCRIPTION
## Summary

### Closes #195 — Payment ReceiptNFT Standard
- `backend/src/services/receipts.ts` — mint, transfer, burn, and query NFT receipts; append-only indexed store with wallet, payment-ID, and tx-hash indexes
- `backend/src/routes/receipts.ts` — `POST /api/v1/receipts/mint`, batch mint, transfer, burn, and query endpoints
- `backend/src/schemas/receipts.ts` — Zod schemas for all receipt inputs
- OpenSea-compatible metadata with `name`, `description`, `image`, `attributes`, and `external_url`
- Batch mint endpoint for backfilling historical payments

### Closes #202 — Event-Driven Architecture with Event Sourcing
- `backend/src/events/event-types.ts` — typed domain events for payments, projects, verifications, receipts, refunds, and splits
- `backend/src/events/event-store.ts` — append-only event store with optimistic concurrency control, per-aggregate streams, global sequence log, and temporal snapshots (state at any point in time)
- `backend/src/events/event-bus.ts` — async pub/sub with per-type and wildcard handlers
- `backend/src/events/projections.ts` — CQRS read models for payments, projects, and verifications (auto-registered via side-effect import)
- `backend/src/routes/events.ts` — admin API for appending events, querying streams, replaying history, and reading projections

### Closes #227 — Advanced Threat Detection with Behavioral Analysis
- `backend/src/types/threat-detection.ts` — types: `BehaviorEvent`, `UserBaseline`, `AnomalyScore`, `ThreatEvent`, `ThreatIntelFeed`
- `backend/src/services/threat-detection.ts` — rolling 7-day baseline modeling, per-action anomaly scoring (new IP, unusual hour, request-rate spike, error-scan pattern, threat-intel IP/UA matching), automated account lockdown at critical severity, false-positive tracking
- `backend/src/routes/threat-detection.ts` — behavior event ingestion, per-user baseline and threat history, account lock/unlock, threat intel refresh

### Closes #206 — Microservices Decomposition with Service Mesh
- `backend/src/services/service-registry.ts` — service registration, deregistration, heartbeat TTL, health-aware round-robin resolution, stale-instance pruning
- `backend/src/middleware/circuit-breaker.ts` — configurable closed/open/half-open state machine; wraps any route or downstream call
- `backend/src/routes/service-mesh.ts` — registry CRUD, service discovery, circuit breaker state inspection and reset

Closes #195 
Closes #202 
Closes #227
Closes #206