### PR TITLE
feat(backend): add API header and content-type version negotiation

### DIFF
--- a/backend/docs/API_VERSIONING.md
+++ b/backend/docs/API_VERSIONING.md
@@ -13,10 +13,12 @@ API versioning can be done in two ways:
    You can explicitly specify the API version in the URL path:
    `GET /api/v1/health`
 
-2. **Header-based**
-   You can omit the version from the URL and provide it via the `API-Version`, `X-API-Version`, or `Accept-Version` headers. If omitted, it defaults to the oldest supported active version (`v1`).
+2. **Header-based or media type versioning**
+   You can omit the version from the URL and provide it via the `API-Version`, `X-API-Version`, or `Accept-Version` headers. You can also version requests through `Content-Type` or `Accept` media type versioning.
    `GET /api/health`
    `API-Version: 1`
+   `Content-Type: application/vnd.agenticpay.v1+json`
+   `Content-Type: application/json; version=1`
 
 All responses include an `X-API-Version` header indicating the API version that processed the request.
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -148,7 +148,15 @@ app.use(
     origin: config.cors.allowedOrigins,
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Trace-Id', REQUEST_ID_HEADER],
+    allowedHeaders: [
+      'Content-Type',
+      'Authorization',
+      'X-Trace-Id',
+      REQUEST_ID_HEADER,
+      'API-Version',
+      'X-API-Version',
+      'Accept-Version',
+    ],
   })
 );
 app.use(express.json());

--- a/backend/src/middleware/__tests__/versioning.test.ts
+++ b/backend/src/middleware/__tests__/versioning.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+import { versionMiddleware } from '../versioning.js';
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    method: 'GET',
+    originalUrl: '/api/health',
+    headers: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+function makeRes(): {
+  res: Response;
+  headers: Record<string, string | string[] | number>;
+} {
+  const headers: Record<string, string | string[] | number> = {};
+
+  const res = {
+    setHeader: vi.fn((name: string, value: string | string[] | number) => {
+      headers[name] = value;
+    }),
+    getHeader: vi.fn((name: string) => headers[name]),
+  } as unknown as Response;
+
+  return { res, headers };
+}
+
+describe('versionMiddleware()', () => {
+  let next: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    next = vi.fn();
+  });
+
+  it('defaults to v1 when no version is provided', () => {
+    const req = makeReq();
+    const { res, headers } = makeRes();
+
+    versionMiddleware(req, res, next);
+
+    expect(req.apiVersion).toBe('v1');
+    expect(headers['X-API-Version']).toBe('v1');
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('reads version from API-Version header', () => {
+    const req = makeReq({ headers: { 'api-version': '1' } });
+    const { res, headers } = makeRes();
+
+    versionMiddleware(req, res, next);
+
+    expect(req.apiVersion).toBe('v1');
+    expect(headers['X-API-Version']).toBe('v1');
+  });
+
+  it('reads version from X-API-Version header', () => {
+    const req = makeReq({ headers: { 'x-api-version': 'V1' } });
+    const { res, headers } = makeRes();
+
+    versionMiddleware(req, res, next);
+
+    expect(req.apiVersion).toBe('v1');
+    expect(headers['X-API-Version']).toBe('v1');
+  });
+
+  it('reads version from Accept-Version header', () => {
+    const req = makeReq({ headers: { 'accept-version': '1' } });
+    const { res, headers } = makeRes();
+
+    versionMiddleware(req, res, next);
+
+    expect(req.apiVersion).toBe('v1');
+    expect(headers['X-API-Version']).toBe('v1');
+  });
+
+  it('reads version from Content-Type media type versioning', () => {
+    const req = makeReq({ headers: { 'content-type': 'application/vnd.agenticpay.v1+json' } });
+    const { res, headers } = makeRes();
+
+    versionMiddleware(req, res, next);
+
+    expect(req.apiVersion).toBe('v1');
+    expect(headers['X-API-Version']).toBe('v1');
+  });
+
+  it('reads version from Content-Type version parameter', () => {
+    const req = makeReq({ headers: { 'content-type': 'application/json; version=1' } });
+    const { res, headers } = makeRes();
+
+    versionMiddleware(req, res, next);
+
+    expect(req.apiVersion).toBe('v1');
+    expect(headers['X-API-Version']).toBe('v1');
+  });
+
+  it('parses version from URL when path includes version', () => {
+    const req = makeReq({ originalUrl: '/api/v1/health' });
+    const { res, headers } = makeRes();
+
+    versionMiddleware(req, res, next);
+
+    expect(req.apiVersion).toBe('v1');
+    expect(headers['X-API-Version']).toBe('v1');
+  });
+});

--- a/backend/src/middleware/versioning.ts
+++ b/backend/src/middleware/versioning.ts
@@ -6,12 +6,47 @@ declare module 'express-serve-static-core' {
   }
 }
 
+function normalizeVersionValue(value?: string | string[]): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const rawVersion = Array.isArray(value) ? value[0] : value;
+  const versionString = rawVersion?.toString().trim();
+
+  if (!versionString) {
+    return undefined;
+  }
+
+  if (/^v?\d+$/i.test(versionString)) {
+    return `v${versionString.replace(/^v/i, '')}`;
+  }
+
+  const mimeVersionMatch = versionString.match(/v(?<version>\d+)(?:\+|;|$)/i);
+  if (mimeVersionMatch?.groups?.version) {
+    return `v${mimeVersionMatch.groups.version}`;
+  }
+
+  const parameterVersionMatch = versionString.match(/version\s*=\s*"?(\d+)"?/i);
+  if (parameterVersionMatch) {
+    return `v${parameterVersionMatch[1]}`;
+  }
+
+  return undefined;
+}
+
 export const versionMiddleware = (req: Request, res: Response, next: NextFunction) => {
-  const headerVersion = req.headers['api-version'] || req.headers['x-api-version'] || req.headers['accept-version'];
+  const headerVersion =
+    normalizeVersionValue(req.headers['api-version']) ||
+    normalizeVersionValue(req.headers['x-api-version']) ||
+    normalizeVersionValue(req.headers['accept-version']) ||
+    normalizeVersionValue(req.headers['content-type']) ||
+    normalizeVersionValue(req.headers['accept']);
+
   let version = 'v1';
 
   if (headerVersion) {
-    version = `v${headerVersion.toString().replace(/^v/i, '')}`;
+    version = headerVersion;
   } else {
     const match = req.originalUrl.match(/^\/api\/(v\d+)\//);
     if (match) {


### PR DESCRIPTION
Title: Add API header and Content-Type version negotiation

Add backend API version negotiation using request headers:
API-Version
X-API-Version
Accept-Version
Add media type versioning support via:
Content-Type: application/vnd.agenticpay.v1+json
Content-Type: application/json; version=1
Accept: application/vnd.agenticpay.v1+json
Preserve existing URL versioning behavior for /api/v1/...
Maintain backward compatibility by defaulting to v1
Update CORS configuration to allow version negotiation headers
Document header and media type versioning in API_VERSIONING.md
Add backend middleware tests covering header and content-type version parsing

# Testing
npm exec vitest run src/middleware/__tests__/versioning.test.ts
npm exec eslint src/middleware/versioning.ts src/middleware/__tests__/versioning.test.ts

Closes #93 