### PR TITLE
feat(backend): tax reports, payment-link protection, MPC tx routing & session tests

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -81,6 +81,7 @@ import { escrowRouter } from './routes/escrow.js';
 import { multisigRouter } from './routes/multisig.js';
 import { fiatPaymentsRouter } from './routes/fiat-payments.js';
 import { paymentLinksRouter } from './routes/payment-links.js';
+import { taxRouter } from './routes/tax.js';
 import { projectsRouter } from './routes/projects.js';
 import { graphQLRouter, graphQLWsRouter } from './graphql/gateway.js';
 import { fraudDetectionRouter } from './routes/fraud-detection.js';
@@ -283,6 +284,9 @@ app.use('/api/v1/fiat-payments', fiatPaymentsRouter);
 
 // Merchant dynamic payment links
 app.use('/api/v1/payment-links', paymentLinksRouter);
+
+// Merchant tax report generation (summary, 1099-K, VAT, nexus, CSV export)
+app.use('/api/v1/tax', taxRouter);
 
 // Project + milestone delivery approval workflow
 app.use('/api/v1/projects', projectsRouter);

--- a/backend/src/routes/payment-links.ts
+++ b/backend/src/routes/payment-links.ts
@@ -146,20 +146,46 @@ paymentLinksRouter.get(
   })
 );
 
+function enforcePassword(slug: string, link: { requiresPassword: boolean }, password: unknown): void {
+  if (!link.requiresPassword) {
+    return;
+  }
+  const result = paymentLinksService.verifyPassword(slug, typeof password === 'string' ? password : '');
+  if (result.ok) {
+    return;
+  }
+  if (result.reason === 'locked') {
+    throw new AppError(
+      429,
+      'Too many incorrect password attempts. Try again later.',
+      'PAYMENT_LINK_LOCKED'
+    );
+  }
+  throw new AppError(401, 'A valid password is required for this link', 'PAYMENT_LINK_PASSWORD_REQUIRED');
+}
+
 paymentLinksRouter.get(
   '/r/:slug',
   redirectRateLimiter,
   asyncHandler(async (req, res) => {
     const slug = Array.isArray(req.params.slug) ? req.params.slug[0] : req.params.slug;
     const source = req.query.source ? String(req.query.source) : 'direct';
-    const link = paymentLinksService.trackView(slug, source);
 
-    if (!link) {
+    const existing = paymentLinksService.getBySlug(slug);
+    if (!existing) {
       throw new AppError(404, 'Payment link not found', 'NOT_FOUND');
     }
-
-    if (!paymentLinksService.isUsable(link)) {
+    if (!paymentLinksService.isUsable(existing)) {
       throw new AppError(410, 'Payment link has expired or been disabled', 'PAYMENT_LINK_EXPIRED');
+    }
+
+    // Gate protected links before counting the view, so brute-force probes
+    // can't inflate analytics.
+    enforcePassword(slug, existing, req.query.password);
+
+    const link = paymentLinksService.trackView(slug, source);
+    if (!link) {
+      throw new AppError(404, 'Payment link not found', 'NOT_FOUND');
     }
 
     const accentColor = link.brand?.accentColor || '#0B3A80';
@@ -201,6 +227,16 @@ paymentLinksRouter.post(
   asyncHandler(async (req, res) => {
     const slug = Array.isArray(req.params.slug) ? req.params.slug[0] : req.params.slug;
     const source = req.body.source || 'direct';
+
+    const existing = paymentLinksService.getBySlug(slug);
+    if (!existing) {
+      throw new AppError(404, 'Payment link not found', 'NOT_FOUND');
+    }
+    if (!paymentLinksService.isUsable(existing)) {
+      throw new AppError(410, 'Payment link has expired, been disabled, or reached its usage limit', 'PAYMENT_LINK_EXPIRED');
+    }
+
+    enforcePassword(slug, existing, req.body.password);
 
     const completed = paymentLinksService.complete(slug, source);
     if (!completed) {

--- a/backend/src/routes/tax.ts
+++ b/backend/src/routes/tax.ts
@@ -1,0 +1,137 @@
+// Tax report API routes — Issue #351
+// GET  /api/v1/tax/summary   — tax-year summary (gross/net volume)
+// GET  /api/v1/tax/1099-k    — US 1099-K form
+// GET  /api/v1/tax/vat       — VAT report for a jurisdiction
+// GET  /api/v1/tax/nexus     — multi-jurisdiction economic-nexus detection
+// GET  /api/v1/tax/export    — CSV export (summary | 1099-k)
+// POST /api/v1/tax/track     — ingest a taxable transaction
+
+import { Router, Request } from 'express';
+import { AppError, asyncHandler } from '../middleware/errorHandler.js';
+import { taxReportService } from '../services/tax-reports.js';
+
+export const taxRouter = Router();
+
+function requireMerchantId(req: Request): string {
+  const merchantId = req.query.merchantId ?? req.body?.merchantId;
+  if (typeof merchantId !== 'string' || merchantId.length === 0) {
+    throw new AppError(400, 'merchantId is required', 'VALIDATION_ERROR');
+  }
+  return merchantId;
+}
+
+function parseYear(req: Request): number {
+  const raw = req.query.year;
+  if (typeof raw === 'string') {
+    const year = parseInt(raw, 10);
+    if (!Number.isNaN(year) && year >= 2000 && year <= 2100) {
+      return year;
+    }
+    throw new AppError(400, 'year must be between 2000 and 2100', 'VALIDATION_ERROR');
+  }
+  return new Date().getUTCFullYear();
+}
+
+taxRouter.get(
+  '/summary',
+  asyncHandler(async (req, res) => {
+    const merchantId = requireMerchantId(req);
+    const reportingCurrency =
+      typeof req.query.reportingCurrency === 'string' ? req.query.reportingCurrency : undefined;
+    res.json({ data: taxReportService.getYearSummary(merchantId, parseYear(req), { reportingCurrency }) });
+  })
+);
+
+taxRouter.get(
+  '/1099-k',
+  asyncHandler(async (req, res) => {
+    const merchantId = requireMerchantId(req);
+    res.json({ data: taxReportService.generate1099K(merchantId, parseYear(req)) });
+  })
+);
+
+taxRouter.get(
+  '/vat',
+  asyncHandler(async (req, res) => {
+    const merchantId = requireMerchantId(req);
+    const jurisdiction = req.query.jurisdiction;
+    const rate = Number(req.query.rate);
+    if (typeof jurisdiction !== 'string' || jurisdiction.length === 0) {
+      throw new AppError(400, 'jurisdiction is required', 'VALIDATION_ERROR');
+    }
+    if (Number.isNaN(rate)) {
+      throw new AppError(400, 'rate is required (fraction, e.g. 0.2)', 'VALIDATION_ERROR');
+    }
+    res.json({
+      data: taxReportService.generateVatReport(merchantId, parseYear(req), {
+        jurisdiction,
+        rate,
+        amountsIncludeVat: String(req.query.amountsIncludeVat).toLowerCase() === 'true',
+      }),
+    });
+  })
+);
+
+taxRouter.get(
+  '/nexus',
+  asyncHandler(async (req, res) => {
+    const merchantId = requireMerchantId(req);
+    const amount = req.query.amount ? Number(req.query.amount) : undefined;
+    const transactions = req.query.transactions ? Number(req.query.transactions) : undefined;
+    res.json({
+      data: taxReportService.detectNexus(merchantId, parseYear(req), { amount, transactions }),
+    });
+  })
+);
+
+taxRouter.get(
+  '/export',
+  asyncHandler(async (req, res) => {
+    const merchantId = requireMerchantId(req);
+    const year = parseYear(req);
+    const type = req.query.type === '1099-k' ? '1099-k' : 'summary';
+
+    const csv =
+      type === '1099-k'
+        ? taxReportService.form1099KToCsv(taxReportService.generate1099K(merchantId, year))
+        : taxReportService.summaryToCsv(taxReportService.getYearSummary(merchantId, year));
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="tax-${type}-${merchantId}-${year}.csv"`
+    );
+    res.send(csv);
+  })
+);
+
+taxRouter.post(
+  '/track',
+  asyncHandler(async (req, res) => {
+    const merchantId = requireMerchantId(req);
+    const { id, amount, currency, jurisdiction, type, timestamp } = req.body as Record<string, unknown>;
+
+    if (
+      typeof id !== 'string' ||
+      typeof amount !== 'number' ||
+      amount <= 0 ||
+      typeof currency !== 'string' ||
+      typeof jurisdiction !== 'string' ||
+      (type !== 'sale' && type !== 'refund')
+    ) {
+      throw new AppError(400, 'Invalid taxable transaction payload', 'VALIDATION_ERROR');
+    }
+
+    taxReportService.recordTransaction({
+      id,
+      merchantId,
+      amount,
+      currency,
+      jurisdiction,
+      type,
+      timestamp: typeof timestamp === 'string' ? new Date(timestamp) : new Date(),
+    });
+
+    res.status(201).json({ ok: true });
+  })
+);

--- a/backend/src/schemas/payment-links.ts
+++ b/backend/src/schemas/payment-links.ts
@@ -18,6 +18,8 @@ export const createPaymentLinkSchema = z.object({
   category: z.string().min(1).max(64).optional(),
   metadata: z.record(z.string(), z.string()).optional(),
   brand: brandSchema.optional(),
+  password: z.string().min(4).max(128).optional(),
+  maxUses: z.number().int().positive().max(1_000_000).optional(),
 });
 
 export const bulkCreatePaymentLinkSchema = z.object({
@@ -37,4 +39,5 @@ export const updatePaymentLinkSchema = z.object({
 export const paymentLinkCompletionSchema = z.object({
   amountPaid: z.number().positive(),
   source: z.string().max(64).optional(),
+  password: z.string().max(128).optional(),
 });

--- a/backend/src/services/__tests__/payment-links.test.ts
+++ b/backend/src/services/__tests__/payment-links.test.ts
@@ -82,4 +82,108 @@ describe('paymentLinksService', () => {
     expect(paymentLinksService.list({ merchantId: 'm_4', tag: 'campaign-a' })).toHaveLength(1);
     expect(paymentLinksService.list({ merchantId: 'm_4', category: 'social' })).toHaveLength(1);
   });
+
+  describe('password protection', () => {
+    function makeProtected(password = 'hunter2') {
+      return paymentLinksService.create({
+        merchantId: 'm_pw',
+        amount: 100,
+        currency: 'USD',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        recurrence: 'one_time',
+        tags: [],
+        password,
+      });
+    }
+
+    it('flags the link as protected without storing the password', () => {
+      const link = makeProtected();
+      expect(link.requiresPassword).toBe(true);
+      // The plaintext password must not appear anywhere on the public record.
+      expect(JSON.stringify(link)).not.toContain('hunter2');
+    });
+
+    it('accepts the correct password and rejects an incorrect one', () => {
+      const link = makeProtected();
+      expect(paymentLinksService.verifyPassword(link.slug, 'hunter2')).toEqual({ ok: true });
+      expect(paymentLinksService.verifyPassword(link.slug, 'wrong')).toMatchObject({
+        ok: false,
+        reason: 'invalid_password',
+      });
+    });
+
+    it('locks the link after repeated incorrect attempts', () => {
+      const link = makeProtected();
+      for (let i = 0; i < 4; i++) {
+        expect(paymentLinksService.verifyPassword(link.slug, 'wrong')).toMatchObject({
+          ok: false,
+          reason: 'invalid_password',
+        });
+      }
+      // 5th failure trips the lockout.
+      const locked = paymentLinksService.verifyPassword(link.slug, 'wrong');
+      expect(locked.ok).toBe(false);
+      expect(locked).toMatchObject({ reason: 'locked' });
+      // Even the correct password is refused while locked.
+      expect(paymentLinksService.verifyPassword(link.slug, 'hunter2')).toMatchObject({
+        ok: false,
+        reason: 'locked',
+      });
+    });
+
+    it('returns no_password_required for unprotected links', () => {
+      const link = paymentLinksService.create({
+        merchantId: 'm_pw2',
+        amount: 5,
+        currency: 'USD',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        recurrence: 'one_time',
+        tags: [],
+      });
+      expect(paymentLinksService.verifyPassword(link.slug, 'anything')).toMatchObject({
+        ok: false,
+        reason: 'no_password_required',
+      });
+    });
+  });
+
+  describe('maximum usage limit', () => {
+    it('disables the link once the completion cap is reached', () => {
+      const link = paymentLinksService.create({
+        merchantId: 'm_cap',
+        amount: 25,
+        currency: 'USD',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        recurrence: 'weekly',
+        tags: [],
+        maxUses: 2,
+      });
+
+      paymentLinksService.complete(link.slug);
+      expect(paymentLinksService.isUsable(paymentLinksService.getById(link.id)!)).toBe(true);
+
+      paymentLinksService.complete(link.slug);
+      const stored = paymentLinksService.getById(link.id)!;
+      expect(stored.analytics.completions).toBe(2);
+      expect(paymentLinksService.hasReachedUsageLimit(stored)).toBe(true);
+      expect(stored.isActive).toBe(false);
+      expect(paymentLinksService.isUsable(stored)).toBe(false);
+    });
+
+    it('treats links without maxUses as unlimited', () => {
+      const link = paymentLinksService.create({
+        merchantId: 'm_cap2',
+        amount: 25,
+        currency: 'USD',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        recurrence: 'weekly',
+        tags: [],
+      });
+      for (let i = 0; i < 10; i++) paymentLinksService.complete(link.slug);
+      const stored = paymentLinksService.getById(link.id)!;
+      expect(stored.maxUses).toBeNull();
+      expect(paymentLinksService.hasReachedUsageLimit(stored)).toBe(false);
+      expect(stored.isActive).toBe(true);
+    });
+  });
 });

--- a/backend/src/services/__tests__/session.test.ts
+++ b/backend/src/services/__tests__/session.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkSessionAnomaly,
+  createSession,
+  getSession,
+  getSessionHistory,
+  getUserSessions,
+  terminateOtherSessions,
+  terminateSession,
+  trustDevice,
+} from '../session.js';
+
+// The session store is module-global with no reset hook, so each test uses a
+// unique userId to stay isolated from the others.
+let counter = 0;
+function uniqueUser(): string {
+  counter += 1;
+  return `user_${Date.now()}_${counter}`;
+}
+
+const baseMeta = { deviceId: 'device-a', browser: 'Chrome', os: 'macOS', ip: '10.0.0.1' };
+
+describe('session service', () => {
+  it('creates an active session with the supplied device metadata', () => {
+    const userId = uniqueUser();
+    const session = createSession(userId, baseMeta);
+
+    expect(session.id).toMatch(/^sess_/);
+    expect(session.userId).toBe(userId);
+    expect(session.deviceId).toBe('device-a');
+    expect(session.status).toBe('active');
+    expect(session.isTrusted).toBe(false);
+    expect(getSession(session.id)).toBeDefined();
+  });
+
+  it('enforces the concurrent session limit by evicting the oldest', () => {
+    const userId = uniqueUser();
+    for (let i = 0; i < 6; i++) {
+      createSession(userId, { ...baseMeta, deviceId: `device-${i}` });
+    }
+
+    // Cap is 5 active sessions; the 6th create should have terminated one.
+    expect(getUserSessions(userId)).toHaveLength(5);
+    // History keeps every session, including the terminated one.
+    expect(getSessionHistory(userId)).toHaveLength(6);
+  });
+
+  it('lists only active sessions for the user', () => {
+    const userId = uniqueUser();
+    const a = createSession(userId, baseMeta);
+    const b = createSession(userId, baseMeta);
+    terminateSession(a.id);
+
+    const active = getUserSessions(userId);
+    expect(active).toHaveLength(1);
+    expect(active[0].id).toBe(b.id);
+  });
+
+  it('terminates a specific session and reports success/failure', () => {
+    const session = createSession(uniqueUser(), baseMeta);
+    expect(terminateSession(session.id)).toBe(true);
+    expect(getSession(session.id)?.status).toBe('terminated');
+    expect(terminateSession('sess_does_not_exist')).toBe(false);
+  });
+
+  it('terminates all other sessions except the current one', () => {
+    const userId = uniqueUser();
+    const current = createSession(userId, baseMeta);
+    createSession(userId, baseMeta);
+    createSession(userId, baseMeta);
+
+    const count = terminateOtherSessions(userId, current.id);
+    expect(count).toBe(2);
+
+    const active = getUserSessions(userId);
+    expect(active).toHaveLength(1);
+    expect(active[0].id).toBe(current.id);
+  });
+
+  describe('checkSessionAnomaly', () => {
+    it('flags an IP change for an untrusted session', () => {
+      const session = createSession(uniqueUser(), baseMeta);
+      expect(checkSessionAnomaly(session, '203.0.113.9')).toBe('IP_CHANGE_DETECTED');
+    });
+
+    it('does not flag the same IP', () => {
+      const session = createSession(uniqueUser(), baseMeta);
+      expect(checkSessionAnomaly(session, baseMeta.ip)).toBeNull();
+    });
+
+    it('does not flag IP changes once the device is trusted', () => {
+      const session = createSession(uniqueUser(), baseMeta);
+      trustDevice(session.id);
+      const refreshed = getSession(session.id)!;
+      expect(checkSessionAnomaly(refreshed, '203.0.113.9')).toBeNull();
+    });
+  });
+
+  it('marks a device as trusted', () => {
+    const session = createSession(uniqueUser(), baseMeta);
+    expect(trustDevice(session.id)).toBe(true);
+    expect(getSession(session.id)?.isTrusted).toBe(true);
+    expect(trustDevice('sess_missing')).toBe(false);
+  });
+
+  it('returns session history newest-first including terminated sessions', () => {
+    const userId = uniqueUser();
+    const first = createSession(userId, baseMeta);
+    const second = createSession(userId, baseMeta);
+    terminateSession(first.id);
+
+    const history = getSessionHistory(userId);
+    expect(history).toHaveLength(2);
+    expect(history.map((s) => s.id)).toContain(first.id);
+    expect(history.map((s) => s.id)).toContain(second.id);
+    // Newest-first ordering by createdAt.
+    expect(new Date(history[0].createdAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(history[1].createdAt).getTime(),
+    );
+  });
+});

--- a/backend/src/services/__tests__/tax-reports.test.ts
+++ b/backend/src/services/__tests__/tax-reports.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { TaxReportService, TaxableTransaction } from '../tax-reports.js';
+
+function tx(overrides: Partial<TaxableTransaction>): TaxableTransaction {
+  return {
+    id: overrides.id ?? `tx_${Math.random().toString(36).slice(2)}`,
+    merchantId: overrides.merchantId ?? 'm_1',
+    amount: overrides.amount ?? 100,
+    currency: overrides.currency ?? 'USD',
+    jurisdiction: overrides.jurisdiction ?? 'US',
+    type: overrides.type ?? 'sale',
+    timestamp: overrides.timestamp ?? new Date('2025-06-15T12:00:00Z'),
+  };
+}
+
+describe('TaxReportService', () => {
+  let service: TaxReportService;
+
+  beforeEach(() => {
+    service = new TaxReportService();
+  });
+
+  describe('getYearSummary', () => {
+    it('computes gross, refund and net volume for the year', () => {
+      service.recordMany([
+        tx({ amount: 1000, type: 'sale' }),
+        tx({ amount: 500, type: 'sale' }),
+        tx({ amount: 200, type: 'refund' }),
+        // Different year — must be excluded.
+        tx({ amount: 9999, type: 'sale', timestamp: new Date('2024-01-01T00:00:00Z') }),
+      ]);
+
+      const summary = service.getYearSummary('m_1', 2025);
+      expect(summary.grossVolume).toBe(1500);
+      expect(summary.refundVolume).toBe(200);
+      expect(summary.netVolume).toBe(1300);
+      expect(summary.saleCount).toBe(2);
+      expect(summary.totalTransactionCount).toBe(3);
+    });
+
+    it('breaks down by jurisdiction', () => {
+      service.recordMany([
+        tx({ amount: 300, jurisdiction: 'US' }),
+        tx({ amount: 700, jurisdiction: 'GB' }),
+      ]);
+      const summary = service.getYearSummary('m_1', 2025);
+      const gb = summary.byJurisdiction.find((j) => j.jurisdiction === 'GB');
+      expect(gb?.gross).toBe(700);
+    });
+
+    it('converts multi-currency totals with provided rates', () => {
+      service.recordMany([
+        tx({ amount: 100, currency: 'USD' }),
+        tx({ amount: 100, currency: 'EUR' }),
+      ]);
+      const summary = service.getYearSummary('m_1', 2025, {
+        reportingCurrency: 'USD',
+        rates: { EUR: 1.1 },
+      });
+      expect(summary.grossVolume).toBe(210); // 100 + 100*1.1
+      expect(summary.warnings).toHaveLength(0);
+    });
+
+    it('warns when a currency has no conversion rate', () => {
+      service.recordMany([tx({ amount: 100, currency: 'JPY' })]);
+      const summary = service.getYearSummary('m_1', 2025, { reportingCurrency: 'USD' });
+      expect(summary.warnings.length).toBeGreaterThan(0);
+    });
+
+    it('includes a 7-year retention policy', () => {
+      const summary = service.getYearSummary('m_1', 2025);
+      expect(summary.retention.retentionYears).toBe(7);
+      expect(summary.retention.retainUntil).toContain('2032-12-31');
+    });
+  });
+
+  describe('generate1099K', () => {
+    it('flags reporting required when both thresholds are met', () => {
+      for (let i = 0; i < 200; i++) {
+        service.recordTransaction(tx({ id: `s${i}`, amount: 150, type: 'sale' }));
+      }
+      const form = service.generate1099K('m_1', 2025);
+      expect(form.grossAmount).toBe(30_000);
+      expect(form.cardNotPresentCount).toBe(200);
+      expect(form.reportingRequired).toBe(true);
+      expect(form.monthlyGross[5]).toBe(30_000); // June (index 5)
+    });
+
+    it('does not require reporting below the threshold', () => {
+      service.recordTransaction(tx({ amount: 100, type: 'sale' }));
+      const form = service.generate1099K('m_1', 2025);
+      expect(form.reportingRequired).toBe(false);
+    });
+
+    it('honours a custom threshold', () => {
+      service.recordTransaction(tx({ amount: 5000, type: 'sale' }));
+      const form = service.generate1099K('m_1', 2025, { grossAmount: 600 });
+      expect(form.reportingRequired).toBe(true);
+    });
+
+    it('only counts US sales', () => {
+      service.recordTransaction(tx({ amount: 5000, jurisdiction: 'GB', type: 'sale' }));
+      const form = service.generate1099K('m_1', 2025, { grossAmount: 100 });
+      expect(form.grossAmount).toBe(0);
+      expect(form.reportingRequired).toBe(false);
+    });
+  });
+
+  describe('generateVatReport', () => {
+    it('computes VAT on the net taxable base', () => {
+      service.recordMany([
+        tx({ amount: 1000, jurisdiction: 'GB', type: 'sale', currency: 'GBP' }),
+        tx({ amount: 200, jurisdiction: 'GB', type: 'refund', currency: 'GBP' }),
+      ]);
+      const report = service.generateVatReport('m_1', 2025, { jurisdiction: 'GB', rate: 0.2 });
+      expect(report.taxableBase).toBe(800);
+      expect(report.vatDue).toBe(160);
+      expect(report.currency).toBe('GBP');
+    });
+
+    it('extracts VAT when amounts are VAT-inclusive', () => {
+      service.recordTransaction(tx({ amount: 120, jurisdiction: 'GB', type: 'sale' }));
+      const report = service.generateVatReport('m_1', 2025, {
+        jurisdiction: 'GB',
+        rate: 0.2,
+        amountsIncludeVat: true,
+      });
+      expect(report.taxableBase).toBe(100);
+      expect(report.vatDue).toBe(20);
+    });
+
+    it('rejects an out-of-range rate', () => {
+      expect(() => service.generateVatReport('m_1', 2025, { jurisdiction: 'GB', rate: 1.5 })).toThrow();
+    });
+  });
+
+  describe('detectNexus', () => {
+    it('flags jurisdictions that exceed the amount or transaction threshold', () => {
+      service.recordTransaction(tx({ amount: 150_000, jurisdiction: 'US', type: 'sale' }));
+      for (let i = 0; i < 5; i++) {
+        service.recordTransaction(tx({ id: `gb${i}`, amount: 10, jurisdiction: 'GB', type: 'sale' }));
+      }
+      const results = service.detectNexus('m_1', 2025);
+      const us = results.find((r) => r.jurisdiction === 'US');
+      const gb = results.find((r) => r.jurisdiction === 'GB');
+      expect(us?.hasNexus).toBe(true);
+      expect(gb?.hasNexus).toBe(false);
+    });
+
+    it('respects custom thresholds', () => {
+      for (let i = 0; i < 3; i++) {
+        service.recordTransaction(tx({ id: `t${i}`, amount: 10, jurisdiction: 'CA', type: 'sale' }));
+      }
+      const results = service.detectNexus('m_1', 2025, { transactions: 3 });
+      expect(results.find((r) => r.jurisdiction === 'CA')?.hasNexus).toBe(true);
+    });
+  });
+
+  describe('CSV export', () => {
+    it('exports a summary as CSV with escaped fields', () => {
+      service.recordTransaction(tx({ amount: 1000, type: 'sale' }));
+      const csv = service.summaryToCsv(service.getYearSummary('m_1', 2025));
+      expect(csv).toContain('Gross Volume,1000.00');
+      expect(csv).toContain('Jurisdiction,Gross,Refunds,Net,Count');
+    });
+
+    it('exports a 1099-K as CSV with monthly rows', () => {
+      service.recordTransaction(tx({ amount: 500, type: 'sale' }));
+      const csv = service.form1099KToCsv(service.generate1099K('m_1', 2025));
+      expect(csv).toContain('Form,1099-K');
+      expect(csv).toContain('Jun,500.00');
+    });
+  });
+});

--- a/backend/src/services/__tests__/transactionBuilder.service.test.ts
+++ b/backend/src/services/__tests__/transactionBuilder.service.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { TransactionBuilderService } from '../transactionBuilder.service.js';
+import { clearNodes, registerNode } from '../mpc/nodes.js';
+import { resetHsm } from '../mpc/hsm.js';
+import { __reset, getSigningSession, runCeremony } from '../mpc/coordinator.js';
+import { generateIdentityKeypair } from '../mpc/ed25519.js';
+
+function bootstrapNodes(count: number): string[] {
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const id = `node-${i + 1}`;
+    const { publicKey } = generateIdentityKeypair();
+    registerNode({ id, identityPublicKey: publicKey.toString('hex') });
+    ids.push(id);
+  }
+  return ids;
+}
+
+describe('TransactionBuilderService', () => {
+  let builder: TransactionBuilderService;
+
+  beforeEach(() => {
+    clearNodes();
+    resetHsm();
+    __reset();
+    builder = new TransactionBuilderService();
+  });
+
+  describe('classification', () => {
+    it('treats amounts below the threshold as single-key', () => {
+      expect(builder.isHighValue(9_999)).toBe(false);
+      expect(builder.classify(9_999)).toBe('single');
+    });
+
+    it('treats amounts at or above the threshold as MPC', () => {
+      expect(builder.isHighValue(10_000)).toBe(true);
+      expect(builder.classify(50_000)).toBe('mpc');
+    });
+
+    it('respects a custom threshold and rejects invalid ones', () => {
+      builder.setHighValueThreshold(1_000);
+      expect(builder.classify(1_500)).toBe('mpc');
+      expect(() => builder.setHighValueThreshold(0)).toThrow();
+    });
+  });
+
+  describe('standard-value signing', () => {
+    it('signs immediately with the single-key signer', async () => {
+      const result = await builder.signTransaction({
+        amount: 100,
+        payload: Buffer.from('standard-tx'),
+        requestedBy: 'svc',
+        singleKeySign: (payload) => Buffer.concat([Buffer.from('sig:'), payload]),
+      });
+
+      expect(result.mode).toBe('single');
+      if (result.mode === 'single') {
+        expect(Buffer.from(result.signatureHex, 'hex').toString()).toBe('sig:standard-tx');
+      }
+    });
+
+    it('throws when no single-key signer is supplied', async () => {
+      await expect(
+        builder.signTransaction({
+          amount: 100,
+          payload: Buffer.from('x'),
+          requestedBy: 'svc',
+        }),
+      ).rejects.toThrow(/singleKeySign/);
+    });
+  });
+
+  describe('high-value signing', () => {
+    it('routes through the MPC coordinator and opens a pending session', async () => {
+      const nodes = bootstrapNodes(5);
+      const { key } = runCeremony({ threshold: 3, nodes });
+
+      const result = await builder.signTransaction({
+        amount: 250_000,
+        payload: Buffer.from('high-value-tx'),
+        requestedBy: 'treasury',
+        keyId: key.id,
+      });
+
+      expect(result.mode).toBe('mpc');
+      if (result.mode === 'mpc') {
+        expect(result.threshold).toBe(3);
+        expect(result.quorum).toHaveLength(5);
+        expect(result.status).toBe('pending_signatures');
+        // The session is registered with the coordinator awaiting approvals.
+        const session = getSigningSession(result.sessionId);
+        expect(session?.status).toBe('pending');
+      }
+    });
+
+    it('requires a keyId for high-value transactions', async () => {
+      await expect(
+        builder.signTransaction({
+          amount: 250_000,
+          payload: Buffer.from('x'),
+          requestedBy: 'treasury',
+        }),
+      ).rejects.toThrow(/keyId/);
+    });
+
+    it('rejects an unknown MPC key', async () => {
+      await expect(
+        builder.signTransaction({
+          amount: 250_000,
+          payload: Buffer.from('x'),
+          requestedBy: 'treasury',
+          keyId: 'key_does_not_exist',
+        }),
+      ).rejects.toThrow(/unknown MPC key/);
+    });
+  });
+});

--- a/backend/src/services/payment-links.ts
+++ b/backend/src/services/payment-links.ts
@@ -1,6 +1,11 @@
-import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { createHash, randomBytes, randomUUID, scryptSync, timingSafeEqual } from 'node:crypto';
 
 type Recurrence = 'one_time' | 'weekly' | 'monthly';
+
+/** Failed password attempts before a protected link is temporarily locked. */
+const MAX_PASSWORD_ATTEMPTS = 5;
+/** How long a protected link stays locked after exhausting its attempts. */
+const PASSWORD_LOCKOUT_MS = 15 * 60 * 1000;
 
 export type PaymentLinkRecord = {
   id: string;
@@ -20,6 +25,10 @@ export type PaymentLinkRecord = {
     logoUrl?: string;
     redirectUrl?: string;
   };
+  /** True when the link is password protected. The password itself is never stored. */
+  requiresPassword: boolean;
+  /** Maximum number of completions allowed before the link auto-disables. `null` = unlimited. */
+  maxUses: number | null;
   isActive: boolean;
   createdAt: string;
   updatedAt: string;
@@ -30,6 +39,14 @@ export type PaymentLinkRecord = {
     lastViewedAt: string | null;
     lastCompletedAt: string | null;
   };
+};
+
+/** Internal-only secret material kept out of the public record/JSON responses. */
+type PaymentLinkSecret = {
+  passwordHash: Buffer;
+  passwordSalt: Buffer;
+  failedAttempts: number;
+  lockedUntil: number | null;
 };
 
 type CreatePaymentLinkInput = {
@@ -48,14 +65,29 @@ type CreatePaymentLinkInput = {
     logoUrl?: string;
     redirectUrl?: string;
   };
+  /** Optional password; when set, payers must supply it to view/complete the link. */
+  password?: string;
+  /** Optional cap on completions; omit for unlimited. */
+  maxUses?: number;
 };
+
+export type PasswordCheckResult =
+  | { ok: true }
+  | { ok: false; reason: 'no_password_required' | 'invalid_password' | 'locked'; lockedUntil?: number };
 
 export class PaymentLinksService {
   private links = new Map<string, PaymentLinkRecord>();
   private bySlug = new Map<string, string>();
+  private secrets = new Map<string, PaymentLinkSecret>();
 
   private nowIso(): string {
     return new Date().toISOString();
+  }
+
+  private hashPassword(password: string, salt: Buffer): Buffer {
+    // scrypt is deliberately slow and memory-hard, which blunts offline
+    // brute force if the hashes ever leak.
+    return scryptSync(password, salt, 32);
   }
 
   private generateSlug(): string {
@@ -86,6 +118,8 @@ export class PaymentLinksService {
       category: input.category,
       metadata: input.metadata,
       brand: input.brand,
+      requiresPassword: typeof input.password === 'string' && input.password.length > 0,
+      maxUses: typeof input.maxUses === 'number' ? input.maxUses : null,
       isActive: true,
       createdAt: now,
       updatedAt: now,
@@ -100,7 +134,64 @@ export class PaymentLinksService {
 
     this.links.set(id, link);
     this.bySlug.set(slug, id);
+
+    if (link.requiresPassword) {
+      const salt = randomBytes(16);
+      this.secrets.set(id, {
+        passwordHash: this.hashPassword(input.password as string, salt),
+        passwordSalt: salt,
+        failedAttempts: 0,
+        lockedUntil: null,
+      });
+    }
+
     return link;
+  }
+
+  /**
+   * Verify a payer-supplied password for a protected link. Tracks failed
+   * attempts per link and locks the link after MAX_PASSWORD_ATTEMPTS to blunt
+   * brute-force guessing; a correct password resets the counter.
+   */
+  verifyPassword(slug: string, password: string): PasswordCheckResult {
+    const link = this.getBySlug(slug);
+    if (!link || !link.requiresPassword) {
+      return { ok: false, reason: 'no_password_required' };
+    }
+
+    const secret = this.secrets.get(link.id);
+    if (!secret) {
+      return { ok: false, reason: 'no_password_required' };
+    }
+
+    const now = Date.now();
+    if (secret.lockedUntil && secret.lockedUntil > now) {
+      return { ok: false, reason: 'locked', lockedUntil: secret.lockedUntil };
+    }
+
+    const candidate = this.hashPassword(password, secret.passwordSalt);
+    const matches =
+      candidate.length === secret.passwordHash.length &&
+      timingSafeEqual(candidate, secret.passwordHash);
+
+    if (!matches) {
+      secret.failedAttempts += 1;
+      if (secret.failedAttempts >= MAX_PASSWORD_ATTEMPTS) {
+        secret.lockedUntil = now + PASSWORD_LOCKOUT_MS;
+        secret.failedAttempts = 0;
+        return { ok: false, reason: 'locked', lockedUntil: secret.lockedUntil };
+      }
+      return { ok: false, reason: 'invalid_password' };
+    }
+
+    secret.failedAttempts = 0;
+    secret.lockedUntil = null;
+    return { ok: true };
+  }
+
+  /** Whether the link has reached its configured completion cap. */
+  hasReachedUsageLimit(link: PaymentLinkRecord): boolean {
+    return link.maxUses !== null && link.analytics.completions >= link.maxUses;
   }
 
   bulkCreate(merchantId: string, links: Omit<CreatePaymentLinkInput, 'merchantId'>[]): PaymentLinkRecord[] {
@@ -197,7 +288,8 @@ export class PaymentLinksService {
     link.analytics.lastCompletedAt = this.nowIso();
     link.analytics.bySource[source] = (link.analytics.bySource[source] || 0) + 1;
 
-    if (link.recurrence === 'one_time') {
+    // Disable once it is a single-use link or has hit its usage cap.
+    if (link.recurrence === 'one_time' || this.hasReachedUsageLimit(link)) {
       link.isActive = false;
     }
 
@@ -208,6 +300,9 @@ export class PaymentLinksService {
 
   isUsable(link: PaymentLinkRecord): boolean {
     if (!link.isActive) {
+      return false;
+    }
+    if (this.hasReachedUsageLimit(link)) {
       return false;
     }
     return new Date(link.expiresAt).getTime() > Date.now();
@@ -231,6 +326,7 @@ export class PaymentLinksService {
   resetForTests(): void {
     this.links.clear();
     this.bySlug.clear();
+    this.secrets.clear();
   }
 }
 

--- a/backend/src/services/tax-reports.ts
+++ b/backend/src/services/tax-reports.ts
@@ -1,0 +1,413 @@
+// Tax report generation for merchant compliance — Issue #351
+//
+// Generates the documents merchants need at filing time from their
+// transaction history: a tax-year summary (gross/net volume), a US 1099-K
+// form, configurable VAT reports, multi-jurisdiction economic-nexus
+// detection, and regulatory CSV export. Records carry a retention policy so
+// generated documents can be archived for the required period.
+//
+// Monetary aggregation assumes a single reporting currency. Where a merchant
+// transacts in multiple currencies, pass `rates` to convert into the reporting
+// currency; unconverted currencies are surfaced via `warnings` and a
+// per-currency breakdown so nothing is silently mis-summed.
+
+export type TaxTransactionType = 'sale' | 'refund';
+
+export interface TaxableTransaction {
+  id: string;
+  merchantId: string;
+  /** Positive gross amount in `currency` for both sales and refunds. */
+  amount: number;
+  currency: string;
+  /** ISO 3166-1 alpha-2 jurisdiction code, e.g. 'US', 'GB', 'DE'. */
+  jurisdiction: string;
+  type: TaxTransactionType;
+  timestamp: Date;
+}
+
+export interface CurrencyBreakdown {
+  currency: string;
+  gross: number;
+  refunds: number;
+  net: number;
+  count: number;
+}
+
+export interface JurisdictionBreakdown {
+  jurisdiction: string;
+  gross: number;
+  refunds: number;
+  net: number;
+  count: number;
+}
+
+export interface SummaryOptions {
+  /** Currency the aggregate totals are reported in. Default 'USD'. */
+  reportingCurrency?: string;
+  /** Multipliers from a given currency into the reporting currency. */
+  rates?: Record<string, number>;
+}
+
+export interface TaxYearSummary {
+  merchantId: string;
+  year: number;
+  reportingCurrency: string;
+  grossVolume: number;
+  refundVolume: number;
+  netVolume: number;
+  /** Sale transactions counted toward volume (excludes refunds). */
+  saleCount: number;
+  totalTransactionCount: number;
+  byCurrency: CurrencyBreakdown[];
+  byJurisdiction: JurisdictionBreakdown[];
+  warnings: string[];
+  retention: RetentionPolicy;
+  generatedAt: string;
+}
+
+export interface Form1099KThreshold {
+  grossAmount: number;
+  /** When omitted, only the gross-amount threshold applies. */
+  transactionCount?: number;
+}
+
+export interface Form1099K {
+  formType: '1099-K';
+  merchantId: string;
+  year: number;
+  currency: string;
+  grossAmount: number;
+  cardNotPresentCount: number;
+  /** Gross per calendar month, index 0 = January. */
+  monthlyGross: number[];
+  threshold: Form1099KThreshold;
+  reportingRequired: boolean;
+  retention: RetentionPolicy;
+  generatedAt: string;
+}
+
+export interface VatReportOptions {
+  jurisdiction: string;
+  /** Rate as a fraction, e.g. 0.2 for 20%. */
+  rate: number;
+  /** Treat recorded amounts as VAT-inclusive (extract VAT) rather than net. */
+  amountsIncludeVat?: boolean;
+}
+
+export interface VatReport {
+  reportType: 'VAT';
+  merchantId: string;
+  year: number;
+  jurisdiction: string;
+  rate: number;
+  taxableBase: number;
+  vatDue: number;
+  transactionCount: number;
+  currency: string;
+  retention: RetentionPolicy;
+  generatedAt: string;
+}
+
+export interface NexusThresholds {
+  amount?: number;
+  transactions?: number;
+}
+
+export interface NexusResult {
+  jurisdiction: string;
+  grossAmount: number;
+  transactionCount: number;
+  hasNexus: boolean;
+}
+
+export interface RetentionPolicy {
+  retentionYears: number;
+  /** ISO timestamp until which the document must be retained. */
+  retainUntil: string;
+}
+
+const DEFAULT_1099K_THRESHOLD: Form1099KThreshold = {
+  grossAmount: 20_000,
+  transactionCount: 200,
+};
+
+const DEFAULT_NEXUS_THRESHOLDS: Required<NexusThresholds> = {
+  amount: 100_000,
+  transactions: 200,
+};
+
+const RETENTION_YEARS = 7;
+
+export class TaxReportService {
+  private transactions: TaxableTransaction[] = [];
+
+  recordTransaction(tx: TaxableTransaction): void {
+    this.transactions.push({ ...tx, currency: tx.currency.toUpperCase() });
+  }
+
+  recordMany(txs: TaxableTransaction[]): void {
+    txs.forEach((tx) => this.recordTransaction(tx));
+  }
+
+  /** Tax-year summary with gross/net volume and per-currency/jurisdiction breakdowns. */
+  getYearSummary(merchantId: string, year: number, options: SummaryOptions = {}): TaxYearSummary {
+    const reportingCurrency = (options.reportingCurrency ?? 'USD').toUpperCase();
+    const rates = options.rates ?? {};
+    const warnings: string[] = [];
+    const txs = this.forMerchantYear(merchantId, year);
+
+    const convert = (amount: number, currency: string): number => {
+      if (currency === reportingCurrency) return amount;
+      const rate = rates[currency];
+      if (rate === undefined) {
+        const message = `No exchange rate for ${currency}->${reportingCurrency}; left unconverted`;
+        if (!warnings.includes(message)) warnings.push(message);
+        return amount;
+      }
+      return amount * rate;
+    };
+
+    const currencyMap = new Map<string, CurrencyBreakdown>();
+    const jurisdictionMap = new Map<string, JurisdictionBreakdown>();
+    let grossVolume = 0;
+    let refundVolume = 0;
+    let saleCount = 0;
+
+    for (const tx of txs) {
+      const converted = convert(tx.amount, tx.currency);
+
+      const cur = currencyMap.get(tx.currency) ?? {
+        currency: tx.currency,
+        gross: 0,
+        refunds: 0,
+        net: 0,
+        count: 0,
+      };
+      const jur = jurisdictionMap.get(tx.jurisdiction) ?? {
+        jurisdiction: tx.jurisdiction,
+        gross: 0,
+        refunds: 0,
+        net: 0,
+        count: 0,
+      };
+      cur.count += 1;
+      jur.count += 1;
+
+      if (tx.type === 'sale') {
+        grossVolume += converted;
+        saleCount += 1;
+        cur.gross += tx.amount;
+        jur.gross += converted;
+      } else {
+        refundVolume += converted;
+        cur.refunds += tx.amount;
+        jur.refunds += converted;
+      }
+      cur.net = cur.gross - cur.refunds;
+      jur.net = jur.gross - jur.refunds;
+      currencyMap.set(tx.currency, cur);
+      jurisdictionMap.set(tx.jurisdiction, jur);
+    }
+
+    return {
+      merchantId,
+      year,
+      reportingCurrency,
+      grossVolume: round2(grossVolume),
+      refundVolume: round2(refundVolume),
+      netVolume: round2(grossVolume - refundVolume),
+      saleCount,
+      totalTransactionCount: txs.length,
+      byCurrency: [...currencyMap.values()].map(round2Breakdown),
+      byJurisdiction: [...jurisdictionMap.values()].map(round2Breakdown),
+      warnings,
+      retention: this.getRetentionPolicy(year),
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  /** US 1099-K form. Reports gross sales (not net of refunds) per IRS rules. */
+  generate1099K(
+    merchantId: string,
+    year: number,
+    threshold: Form1099KThreshold = DEFAULT_1099K_THRESHOLD,
+  ): Form1099K {
+    const sales = this.forMerchantYear(merchantId, year).filter(
+      (tx) => tx.type === 'sale' && tx.jurisdiction === 'US',
+    );
+
+    const monthlyGross = new Array<number>(12).fill(0);
+    let grossAmount = 0;
+    for (const tx of sales) {
+      monthlyGross[tx.timestamp.getUTCMonth()] += tx.amount;
+      grossAmount += tx.amount;
+    }
+
+    const meetsGross = grossAmount >= threshold.grossAmount;
+    const meetsCount =
+      threshold.transactionCount === undefined || sales.length >= threshold.transactionCount;
+
+    return {
+      formType: '1099-K',
+      merchantId,
+      year,
+      currency: 'USD',
+      grossAmount: round2(grossAmount),
+      cardNotPresentCount: sales.length,
+      monthlyGross: monthlyGross.map(round2),
+      threshold,
+      reportingRequired: meetsGross && meetsCount,
+      retention: this.getRetentionPolicy(year),
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  /** VAT report for a single jurisdiction at a configurable rate. */
+  generateVatReport(merchantId: string, year: number, options: VatReportOptions): VatReport {
+    if (options.rate < 0 || options.rate > 1) {
+      throw new Error('VAT rate must be a fraction between 0 and 1');
+    }
+
+    const txs = this.forMerchantYear(merchantId, year).filter(
+      (tx) => tx.jurisdiction === options.jurisdiction,
+    );
+    const currency = txs[0]?.currency ?? 'USD';
+
+    let net = 0;
+    for (const tx of txs) {
+      net += tx.type === 'sale' ? tx.amount : -tx.amount;
+    }
+
+    // When recorded amounts already include VAT, back it out of the base.
+    const taxableBase = options.amountsIncludeVat ? net / (1 + options.rate) : net;
+    const vatDue = taxableBase * options.rate;
+
+    return {
+      reportType: 'VAT',
+      merchantId,
+      year,
+      jurisdiction: options.jurisdiction,
+      rate: options.rate,
+      taxableBase: round2(taxableBase),
+      vatDue: round2(vatDue),
+      transactionCount: txs.length,
+      currency,
+      retention: this.getRetentionPolicy(year),
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  /** Economic-nexus detection per jurisdiction against amount/transaction thresholds. */
+  detectNexus(
+    merchantId: string,
+    year: number,
+    thresholds: NexusThresholds = {},
+  ): NexusResult[] {
+    const amountThreshold = thresholds.amount ?? DEFAULT_NEXUS_THRESHOLDS.amount;
+    const txThreshold = thresholds.transactions ?? DEFAULT_NEXUS_THRESHOLDS.transactions;
+
+    const byJurisdiction = new Map<string, { gross: number; count: number }>();
+    for (const tx of this.forMerchantYear(merchantId, year)) {
+      if (tx.type !== 'sale') continue;
+      const agg = byJurisdiction.get(tx.jurisdiction) ?? { gross: 0, count: 0 };
+      agg.gross += tx.amount;
+      agg.count += 1;
+      byJurisdiction.set(tx.jurisdiction, agg);
+    }
+
+    return [...byJurisdiction.entries()]
+      .map(([jurisdiction, agg]) => ({
+        jurisdiction,
+        grossAmount: round2(agg.gross),
+        transactionCount: agg.count,
+        hasNexus: agg.gross >= amountThreshold || agg.count >= txThreshold,
+      }))
+      .sort((a, b) => b.grossAmount - a.grossAmount);
+  }
+
+  getRetentionPolicy(year: number): RetentionPolicy {
+    return {
+      retentionYears: RETENTION_YEARS,
+      retainUntil: new Date(Date.UTC(year + RETENTION_YEARS, 11, 31, 23, 59, 59)).toISOString(),
+    };
+  }
+
+  /** Regulatory CSV export of a tax-year summary. */
+  summaryToCsv(summary: TaxYearSummary): string {
+    const rows: string[][] = [
+      ['Field', 'Value'],
+      ['Merchant', summary.merchantId],
+      ['Tax Year', String(summary.year)],
+      ['Reporting Currency', summary.reportingCurrency],
+      ['Gross Volume', summary.grossVolume.toFixed(2)],
+      ['Refund Volume', summary.refundVolume.toFixed(2)],
+      ['Net Volume', summary.netVolume.toFixed(2)],
+      ['Sale Count', String(summary.saleCount)],
+      ['Total Transactions', String(summary.totalTransactionCount)],
+      [],
+      ['Jurisdiction', 'Gross', 'Refunds', 'Net', 'Count'],
+      ...summary.byJurisdiction.map((j) => [
+        j.jurisdiction,
+        j.gross.toFixed(2),
+        j.refunds.toFixed(2),
+        j.net.toFixed(2),
+        String(j.count),
+      ]),
+    ];
+    return toCsv(rows);
+  }
+
+  /** Regulatory CSV export of a 1099-K form. */
+  form1099KToCsv(form: Form1099K): string {
+    const months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    const rows: string[][] = [
+      ['Form', form.formType],
+      ['Merchant', form.merchantId],
+      ['Tax Year', String(form.year)],
+      ['Currency', form.currency],
+      ['Gross Amount', form.grossAmount.toFixed(2)],
+      ['Transaction Count', String(form.cardNotPresentCount)],
+      ['Reporting Required', form.reportingRequired ? 'YES' : 'NO'],
+      [],
+      ['Month', 'Gross'],
+      ...form.monthlyGross.map((g, i) => [months[i], g.toFixed(2)]),
+    ];
+    return toCsv(rows);
+  }
+
+  resetForTests(): void {
+    this.transactions = [];
+  }
+
+  private forMerchantYear(merchantId: string, year: number): TaxableTransaction[] {
+    return this.transactions.filter(
+      (tx) => tx.merchantId === merchantId && tx.timestamp.getUTCFullYear() === year,
+    );
+  }
+}
+
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+function round2Breakdown<T extends { gross: number; refunds: number; net: number }>(b: T): T {
+  return { ...b, gross: round2(b.gross), refunds: round2(b.refunds), net: round2(b.net) };
+}
+
+function toCsv(rows: string[][]): string {
+  return rows
+    .map((row) => row.map((cell) => escapeCsv(cell)).join(','))
+    .join('\n');
+}
+
+function escapeCsv(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export const taxReportService = new TaxReportService();

--- a/backend/src/services/transactionBuilder.service.ts
+++ b/backend/src/services/transactionBuilder.service.ts
@@ -1,0 +1,105 @@
+// Transaction builder — Issue #329
+//
+// Bridges transaction signing with the MPC module. Standard-value transactions
+// are signed with a single key (fast path); high-value transactions are routed
+// through the M-of-N MPC coordinator, which only releases a signature once a
+// threshold of nodes has approved. This removes the single-key signer as a
+// single point of failure for the transactions that matter most.
+
+import { getKey, startSigningSession } from './mpc/coordinator.js';
+
+/** Default high-value cutoff (in the transaction's base unit). */
+const DEFAULT_HIGH_VALUE_THRESHOLD = 10_000;
+
+export type SigningMode = 'single' | 'mpc';
+
+export interface TransactionSigningRequest {
+  /** Transaction value used to decide the signing path. */
+  amount: number;
+  /** Bytes to sign (e.g. a Stellar transaction hash/envelope). */
+  payload: Buffer;
+  /** Identity of the caller initiating the signature, for audit. */
+  requestedBy: string;
+  /** MPC managed-key id; required for the high-value path. */
+  keyId?: string;
+  /** Single-key signer used for the standard path. */
+  singleKeySign?: (payload: Buffer) => Promise<Buffer> | Buffer;
+  /** Optional MPC signing-session timeout. */
+  timeoutMs?: number;
+}
+
+export type TransactionSigningResult =
+  | { mode: 'single'; signatureHex: string }
+  | {
+      mode: 'mpc';
+      sessionId: string;
+      status: 'pending_signatures';
+      threshold: number;
+      quorum: string[];
+    };
+
+export class TransactionBuilderService {
+  constructor(private highValueThreshold: number = DEFAULT_HIGH_VALUE_THRESHOLD) {}
+
+  setHighValueThreshold(threshold: number): void {
+    if (threshold <= 0) {
+      throw new Error('high-value threshold must be positive');
+    }
+    this.highValueThreshold = threshold;
+  }
+
+  getHighValueThreshold(): number {
+    return this.highValueThreshold;
+  }
+
+  isHighValue(amount: number): boolean {
+    return amount >= this.highValueThreshold;
+  }
+
+  classify(amount: number): SigningMode {
+    return this.isHighValue(amount) ? 'mpc' : 'single';
+  }
+
+  /**
+   * Sign a transaction via the appropriate path.
+   *
+   * - Standard value → signs immediately with `singleKeySign`.
+   * - High value → opens an MPC threshold-signing session and returns it for
+   *   the caller to drive the approval rounds (`coordinator.contribute`). The
+   *   signature is only produced once the threshold is reached.
+   */
+  async signTransaction(request: TransactionSigningRequest): Promise<TransactionSigningResult> {
+    if (this.isHighValue(request.amount)) {
+      if (!request.keyId) {
+        throw new Error('high-value transactions require an MPC keyId');
+      }
+      const key = getKey(request.keyId);
+      if (!key) {
+        throw new Error(`unknown MPC key ${request.keyId}`);
+      }
+
+      const session = startSigningSession({
+        keyId: request.keyId,
+        payload: request.payload,
+        requestedBy: request.requestedBy,
+        timeoutMs: request.timeoutMs,
+      });
+
+      return {
+        mode: 'mpc',
+        sessionId: session.id,
+        status: 'pending_signatures',
+        threshold: key.threshold,
+        quorum: session.quorum,
+      };
+    }
+
+    if (!request.singleKeySign) {
+      throw new Error('singleKeySign is required for standard-value transactions');
+    }
+    const signature = await request.singleKeySign(request.payload);
+    return { mode: 'single', signatureHex: signature.toString('hex') };
+  }
+}
+
+export const transactionBuilderService = new TransactionBuilderService();


### PR DESCRIPTION
## Summary

Closes four backend issues by filling the gaps left in features that were already partially scaffolded on `main`. Each change follows existing conventions (Express routers + Zod schemas, `asyncHandler`/`AppError`, in-memory services, vitest).

### #351 — Tax report generation
The backend previously had only payment analytics (Issue #192) and a client-side tax page; there was **no backend tax generation**. Added a `TaxReportService` (`backend/src/services/tax-reports.ts`) + `/api/v1/tax` routes (`backend/src/routes/tax.ts`, registered in `index.ts`):
- Tax-year summary — gross / refund / net volume, per-currency and per-jurisdiction breakdowns, optional multi-currency conversion with `warnings` for missing rates.
- US **1099-K** form with monthly gross and configurable thresholds (defaults $20k & 200 txns).
- Configurable **VAT** report (supports VAT-inclusive and exclusive amounts).
- Multi-jurisdiction **economic-nexus** detection.
- **7-year retention** metadata and regulatory **CSV export** (summary & 1099-K).

### #350 — Payment link generation
Added the two missing acceptance criteria to the existing payment-links service/route/schema:
- **Password protection** — scrypt-hashed (plaintext never stored), constant-time verification, and per-link lockout after repeated failed attempts (addresses the "brute force on protected links" edge). `/r/:slug` and `/complete` are gated.
- **Maximum usage limit** — a link auto-disables once its completion cap is reached; `isUsable` and `complete` enforce it.

### #329 — MPC threshold signing
The MPC module (Shamir, BFT coordinator, HSM, ed25519) and its tests already existed but nothing wired it into transaction building. Added `transactionBuilder.service.ts` — the integration layer from the issue's scope — which routes **high-value** transactions through the existing M-of-N MPC coordinator (threshold signing session) while keeping standard transactions on the single-key fast path. Threshold is configurable.

### #348 — Session management
The session service/middleware/routes existed but had no tests. Added unit tests covering concurrent-limit eviction, revocation, terminate-others, IP-change anomaly detection, device trust, and history.

## Test plan
- [x] `vitest run` on the 4 new/updated suites — **44 tests pass**
- [x] New/changed files are `tsc` type-clean and `eslint` clean
- [x] Ran the full backend suite to confirm no **new** failures introduced

## Out of scope (pre-existing on `main`, not caused by this PR)
- `npm run build` (`tsc`) already fails with ~220 errors across the repo (missing `ethers`/`pino`/`circomlib`/`qrcode` types, JSX in `src/jobs/page.tsx`, `string | string[]` route typing, etc.).
- The full test suite has ~49 pre-existing failures: `jest is not defined` in the 2FA vitest specs, missing `pino`/`ethers` modules, a `dotenv` crash in `config/env.js`, and mpc/gas route specs receiving HTML 500s. None touch the files in this PR.

Closes #329
Closes #348
Closes #350
Closes #351