### PR TITLE
feat: resolve issues #371, #372, #373, #391 — shared types, event DLQ, functional ErrorBoundary, idempotency enhancements

### DIFF
--- a/backend/src/events/dead-letter-queue.ts
+++ b/backend/src/events/dead-letter-queue.ts
@@ -1,0 +1,75 @@
+import type { StoredEvent } from './event-types.js';
+
+export interface DeadLetterEntry {
+  id: string;
+  event: StoredEvent;
+  handlerName: string;
+  error: string;
+  failedAt: string;
+  retryCount: number;
+  lastRetryAt: string | null;
+  resolvedAt: string | null;
+}
+
+const queue: DeadLetterEntry[] = [];
+let nextId = 1;
+
+export function addToDeadLetterQueue(
+  event: StoredEvent,
+  handlerName: string,
+  error: unknown,
+  retryCount = 0
+): DeadLetterEntry {
+  const entry: DeadLetterEntry = {
+    id: `dlq-${nextId++}`,
+    event,
+    handlerName,
+    error: error instanceof Error ? error.message : String(error),
+    failedAt: new Date().toISOString(),
+    retryCount,
+    lastRetryAt: retryCount > 0 ? new Date().toISOString() : null,
+    resolvedAt: null,
+  };
+  queue.push(entry);
+  return entry;
+}
+
+export function getDeadLetterQueue(): DeadLetterEntry[] {
+  return queue.filter((e) => e.resolvedAt === null);
+}
+
+export function getAllDeadLetterEntries(): DeadLetterEntry[] {
+  return [...queue];
+}
+
+export function resolveDeadLetterEntry(id: string): boolean {
+  const entry = queue.find((e) => e.id === id);
+  if (!entry || entry.resolvedAt !== null) return false;
+  entry.resolvedAt = new Date().toISOString();
+  return true;
+}
+
+export function getDeadLetterStats() {
+  const unresolved = queue.filter((e) => e.resolvedAt === null);
+  const byHandler: Record<string, number> = {};
+  for (const e of unresolved) {
+    byHandler[e.handlerName] = (byHandler[e.handlerName] ?? 0) + 1;
+  }
+  return {
+    total: queue.length,
+    unresolved: unresolved.length,
+    byHandler,
+  };
+}
+
+/** Removes resolved entries older than `maxAgeMs` to bound memory growth. */
+export function purgeResolvedEntries(maxAgeMs = 7 * 24 * 60 * 60 * 1000): number {
+  const cutoff = Date.now() - maxAgeMs;
+  const before = queue.length;
+  const kept = queue.filter(
+    (e) => e.resolvedAt === null || new Date(e.resolvedAt).getTime() > cutoff
+  );
+  queue.length = 0;
+  queue.push(...kept);
+  return before - kept.length;
+}

--- a/backend/src/events/event-bus.ts
+++ b/backend/src/events/event-bus.ts
@@ -1,5 +1,6 @@
 import type { DomainEventType, EventHandler, StoredEvent } from './event-types.js';
 import type { AgenticPayWebSocketServer } from '../websocket/server.js';
+import { addToDeadLetterQueue } from './dead-letter-queue.js';
 
 type WildcardHandler = (event: StoredEvent) => void | Promise<void>;
 
@@ -21,7 +22,6 @@ export function subscribe<T = unknown>(type: DomainEventType, handler: EventHand
   const set = handlers.get(type) ?? new Set<EventHandler>();
   set.add(handler as EventHandler);
   handlers.set(type, set);
-
   return () => {
     set.delete(handler as EventHandler);
   };
@@ -32,14 +32,26 @@ export function subscribeAll(handler: WildcardHandler): () => void {
   return () => wildcardHandlers.delete(handler);
 }
 
+async function invokeHandler(
+  handler: (event: StoredEvent) => void | Promise<void>,
+  event: StoredEvent
+): Promise<void> {
+  try {
+    await handler(event);
+  } catch (err) {
+    addToDeadLetterQueue(event, handler.name || 'anonymous', err);
+    console.error(`[event-bus] Handler "${handler.name || 'anonymous'}" failed for event "${event.type}":`, err);
+  }
+}
+
 export async function publish(event: StoredEvent): Promise<void> {
   const typed = handlers.get(event.type);
   if (typed) {
-    await Promise.all(Array.from(typed).map((h) => h(event)));
+    await Promise.all(Array.from(typed).map((h) => invokeHandler(h, event)));
   }
 
   if (wildcardHandlers.size > 0) {
-    await Promise.all(Array.from(wildcardHandlers).map((h) => h(event)));
+    await Promise.all(Array.from(wildcardHandlers).map((h) => invokeHandler(h, event)));
   }
 
   const channel = channelByEventPrefix.find(({ prefix }) => event.type.startsWith(prefix))?.channel;

--- a/backend/src/events/idempotent-handler.ts
+++ b/backend/src/events/idempotent-handler.ts
@@ -1,0 +1,32 @@
+import type { EventHandler, StoredEvent } from './event-types.js';
+
+/**
+ * Wraps an event handler so it processes each event id exactly once.
+ * Duplicate deliveries (same event.id) are silently dropped.
+ */
+export function idempotentHandler<T = unknown>(
+  handler: EventHandler<T>,
+  processedStore: Set<string> = new Set()
+): EventHandler<T> {
+  async function wrappedHandler(event: StoredEvent<T>): Promise<void> {
+    if (processedStore.has(event.id)) {
+      return;
+    }
+    processedStore.add(event.id);
+    await handler(event);
+  }
+
+  Object.defineProperty(wrappedHandler, 'name', {
+    value: `idempotent(${handler.name || 'anonymous'})`,
+  });
+
+  return wrappedHandler;
+}
+
+/**
+ * Creates a shared processed-ids store so a group of handlers can share
+ * deduplication state (useful when multiple handlers process the same stream).
+ */
+export function createProcessedStore(): Set<string> {
+  return new Set<string>();
+}

--- a/backend/src/events/index.ts
+++ b/backend/src/events/index.ts
@@ -1,0 +1,6 @@
+export * from './event-types.js';
+export * from './event-bus.js';
+export * from './event-store.js';
+export * from './projections.js';
+export * from './dead-letter-queue.js';
+export * from './idempotent-handler.js';

--- a/backend/src/middleware/idempotency.js
+++ b/backend/src/middleware/idempotency.js
@@ -1,51 +1,93 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.clearIdempotencyCache = exports.idempotency = void 0;
-// In-memory cache for idempotency keys
+exports.clearIdempotencyCache = exports.getIdempotencyCacheStats = exports.purgeExpiredIdempotencyKeys = exports.idempotency = void 0;
+
+var inFlight = new Map();
 var idempotencyCache = new Map();
-// Default TTL is 24 hours (in milliseconds)
 var DEFAULT_TTL = 24 * 60 * 60 * 1000;
+var MAX_KEY_LENGTH = 255;
+
+function extractIdempotencyKey(req) {
+    return req.headers['idempotency-key'] || req.headers['x-idempotency-key'];
+}
+
+function validateKey(key) {
+    if (key.length > MAX_KEY_LENGTH) {
+        return "Idempotency-Key must not exceed ".concat(MAX_KEY_LENGTH, " characters.");
+    }
+    return null;
+}
+
 var idempotency = function (ttl) {
     if (ttl === void 0) { ttl = DEFAULT_TTL; }
     return function (req, res, next) {
-        var key = req.headers['x-idempotency-key'];
+        var key = extractIdempotencyKey(req);
         if (!key) {
-            // If no key is provided, proceed normally.
             return next();
         }
-        // Include the original URL to scope the key per route
+        var validationError = validateKey(key);
+        if (validationError) {
+            return res.status(400).json({ error: 'invalid_idempotency_key', message: validationError });
+        }
         var cacheKey = "".concat(req.method, ":").concat(req.originalUrl, ":").concat(key);
         var cached = idempotencyCache.get(cacheKey);
         if (cached) {
             if (Date.now() < cached.expiresAt) {
-                // Return cached response instantly
                 return res.status(cached.statusCode).json(cached.response);
             }
-            else {
-                // Expired, remove from cache and proceed
-                idempotencyCache.delete(cacheKey);
-            }
+            idempotencyCache.delete(cacheKey);
         }
-        // Intercept res.json to capture the response
+        if (inFlight.get(cacheKey)) {
+            return res.status(409).json({
+                error: 'idempotency_key_in_use',
+                message: 'A request with this Idempotency-Key is already being processed. Retry after it completes.',
+            });
+        }
+        inFlight.set(cacheKey, true);
         var originalJson = res.json.bind(res);
         res.json = function (body) {
-            // Cache the response if status is successful or we want to cache errors too
-            // Usually we cache 2xx and 4xx responses, but 5xx might be transient.
-            // For simplicity, we cache all completed responses that used this key.
-            idempotencyCache.set(cacheKey, {
-                response: body,
-                statusCode: res.statusCode,
-                expiresAt: Date.now() + ttl,
-            });
-            // Call the original res.json
+            inFlight.delete(cacheKey);
+            if (res.statusCode < 500) {
+                idempotencyCache.set(cacheKey, {
+                    response: body,
+                    statusCode: res.statusCode,
+                    expiresAt: Date.now() + ttl,
+                    completedAt: Date.now(),
+                });
+            }
             return originalJson(body);
         };
+        res.on('close', function () {
+            inFlight.delete(cacheKey);
+        });
         next();
     };
 };
 exports.idempotency = idempotency;
-// Exported for testing purposes
+
+var purgeExpiredIdempotencyKeys = function () {
+    var now = Date.now();
+    var purged = 0;
+    idempotencyCache.forEach(function (entry, key) {
+        if (now >= entry.expiresAt) {
+            idempotencyCache.delete(key);
+            purged++;
+        }
+    });
+    return purged;
+};
+exports.purgeExpiredIdempotencyKeys = purgeExpiredIdempotencyKeys;
+
+var getIdempotencyCacheStats = function () {
+    return {
+        cachedKeys: idempotencyCache.size,
+        inFlightKeys: inFlight.size,
+    };
+};
+exports.getIdempotencyCacheStats = getIdempotencyCacheStats;
+
 var clearIdempotencyCache = function () {
     idempotencyCache.clear();
+    inFlight.clear();
 };
 exports.clearIdempotencyCache = clearIdempotencyCache;

--- a/backend/src/middleware/idempotency.ts
+++ b/backend/src/middleware/idempotency.ts
@@ -4,60 +4,122 @@ interface CacheEntry {
   response: any;
   statusCode: number;
   expiresAt: number;
+  completedAt: number;
 }
 
-// In-memory cache for idempotency keys
+/** In-flight request tracker — prevents two concurrent calls with same key racing each other. */
+const inFlight = new Map<string, boolean>();
+
+/** Completed response cache keyed by `METHOD:URL:idempotency-key`. */
 const idempotencyCache = new Map<string, CacheEntry>();
 
-// Default TTL is 24 hours (in milliseconds)
-const DEFAULT_TTL = 24 * 60 * 60 * 1000;
+const DEFAULT_TTL = 24 * 60 * 60 * 1000; // 24 hours in ms
+const MAX_KEY_LENGTH = 255;
+
+/** Accepts both the standard `Idempotency-Key` and legacy `X-Idempotency-Key` headers. */
+function extractIdempotencyKey(req: Request): string | undefined {
+  return (
+    (req.headers['idempotency-key'] as string | undefined) ??
+    (req.headers['x-idempotency-key'] as string | undefined)
+  );
+}
+
+function validateKey(key: string): string | null {
+  if (key.length > MAX_KEY_LENGTH) {
+    return `Idempotency-Key must not exceed ${MAX_KEY_LENGTH} characters.`;
+  }
+  return null;
+}
 
 export const idempotency = (ttl: number = DEFAULT_TTL) => {
   return (req: Request, res: Response, next: NextFunction) => {
-    const key = req.headers['x-idempotency-key'] as string;
+    const key = extractIdempotencyKey(req);
 
     if (!key) {
-      // If no key is provided, proceed normally.
       return next();
     }
 
-    // Include the original URL to scope the key per route
-    const cacheKey = `${req.method}:${req.originalUrl}:${key}`;
-
-    const cached = idempotencyCache.get(cacheKey);
-
-    if (cached) {
-      if (Date.now() < cached.expiresAt) {
-        // Return cached response instantly
-        return res.status(cached.statusCode).json(cached.response);
-      } else {
-        // Expired, remove from cache and proceed
-        idempotencyCache.delete(cacheKey);
-      }
+    const validationError = validateKey(key);
+    if (validationError) {
+      return res.status(400).json({ error: 'invalid_idempotency_key', message: validationError });
     }
 
-    // Intercept res.json to capture the response
-    const originalJson = res.json.bind(res);
+    // Scope the cache key to method + route so the same UUID can't be reused across endpoints
+    const cacheKey = `${req.method}:${req.originalUrl}:${key}`;
 
-    res.json = (body: any) => {
-      // Cache the response if status is successful or we want to cache errors too
-      // Usually we cache 2xx and 4xx responses, but 5xx might be transient.
-      // For simplicity, we cache all completed responses that used this key.
-      idempotencyCache.set(cacheKey, {
-        response: body,
-        statusCode: res.statusCode,
-        expiresAt: Date.now() + ttl,
+    // --- Check completed-response cache ---
+    const cached = idempotencyCache.get(cacheKey);
+    if (cached) {
+      if (Date.now() < cached.expiresAt) {
+        return res.status(cached.statusCode).json(cached.response);
+      }
+      idempotencyCache.delete(cacheKey);
+    }
+
+    // --- Collision detection: same key already in-flight ---
+    if (inFlight.get(cacheKey)) {
+      return res.status(409).json({
+        error: 'idempotency_key_in_use',
+        message:
+          'A request with this Idempotency-Key is already being processed. Retry after it completes.',
       });
+    }
 
-      // Call the original res.json
+    inFlight.set(cacheKey, true);
+
+    // Intercept res.json to persist the final response
+    const originalJson = res.json.bind(res);
+    res.json = (body: any) => {
+      inFlight.delete(cacheKey);
+
+      // Cache 2xx and 4xx (client errors); skip 5xx as they may be transient
+      if (res.statusCode < 500) {
+        idempotencyCache.set(cacheKey, {
+          response: body,
+          statusCode: res.statusCode,
+          expiresAt: Date.now() + ttl,
+          completedAt: Date.now(),
+        });
+      }
+
       return originalJson(body);
     };
+
+    // Clear in-flight marker on premature connection close (no response sent)
+    res.on('close', () => {
+      inFlight.delete(cacheKey);
+    });
 
     next();
   };
 };
 
-// Exported for testing purposes
+/**
+ * Removes all cache entries whose TTL has expired.
+ * Call this from a scheduled job (e.g. every hour) to bound memory usage.
+ */
+export function purgeExpiredIdempotencyKeys(): number {
+  const now = Date.now();
+  let purged = 0;
+  for (const [cacheKey, entry] of idempotencyCache) {
+    if (now >= entry.expiresAt) {
+      idempotencyCache.delete(cacheKey);
+      purged++;
+    }
+  }
+  return purged;
+}
+
+/** Returns a snapshot of current cache stats for monitoring. */
+export function getIdempotencyCacheStats() {
+  return {
+    cachedKeys: idempotencyCache.size,
+    inFlightKeys: inFlight.size,
+  };
+}
+
+/** Exported for testing purposes. */
 export const clearIdempotencyCache = () => {
   idempotencyCache.clear();
+  inFlight.clear();
 };

--- a/frontend/components/errors/ErrorBoundary.tsx
+++ b/frontend/components/errors/ErrorBoundary.tsx
@@ -1,17 +1,28 @@
 'use client';
 
-import { Component, Fragment, ReactNode, ErrorInfo } from 'react';
+import {
+  Component,
+  Fragment,
+  ReactNode,
+  ErrorInfo,
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+} from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { AlertCircle } from 'lucide-react';
 
-interface Props {
+interface ErrorBoundaryProps {
   children: ReactNode;
   resetKey?: string;
   context?: string;
+  fallback?: ReactNode;
 }
 
-interface State {
+interface ErrorBoundaryState {
   hasError: boolean;
   error: Error | null;
   resetCount: number;
@@ -34,27 +45,75 @@ declare global {
 
 function logErrorToMonitoring(error: Error, errorInfo: ErrorInfo, context?: string) {
   window.Sentry?.captureException?.(error, {
-    extra: {
-      componentStack: errorInfo.componentStack,
-    },
+    extra: { componentStack: errorInfo.componentStack },
     tags: context ? { boundary: context } : undefined,
   });
-
   window.reportError?.(error);
   console.error('Error caught by boundary:', error, errorInfo);
 }
 
-export class ErrorBoundary extends Component<Props, State> {
-  constructor(props: Props) {
+// ─── Default fallback UI ──────────────────────────────────────────────────────
+
+function DefaultFallback({ error, onReset }: { error: Error | null; onReset: () => void }) {
+  return (
+    <div className="flex min-h-[400px] items-center justify-center p-6">
+      <Card className="w-full max-w-lg border-red-200 shadow-sm">
+        <CardHeader className="items-center text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-50">
+            <AlertCircle className="h-6 w-6 text-red-500" />
+          </div>
+          <CardTitle>We hit a problem loading this page</CardTitle>
+          <CardDescription>
+            Something unexpected happened. You can try again, and if it keeps happening our team can
+            investigate it.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="rounded-md bg-muted px-4 py-3 text-sm text-muted-foreground">
+            {error?.message || 'An unexpected error occurred.'}
+          </p>
+        </CardContent>
+        <CardFooter className="justify-center">
+          <Button onClick={onReset}>Retry</Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Context for functional consumers ────────────────────────────────────────
+
+interface ErrorBoundaryContextValue {
+  resetBoundary: () => void;
+}
+
+const ErrorBoundaryContext = createContext<ErrorBoundaryContextValue | null>(null);
+
+/** Access the nearest error boundary's reset function from any functional component. */
+export function useErrorBoundary(): ErrorBoundaryContextValue {
+  const ctx = useContext(ErrorBoundaryContext);
+  if (!ctx) {
+    throw new Error('useErrorBoundary must be used inside an <ErrorBoundary>');
+  }
+  return ctx;
+}
+
+// ─── Class boundary (React requires a class for getDerivedStateFromError) ────
+
+class InternalErrorBoundary extends Component<
+  ErrorBoundaryProps & { onReset: () => void },
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps & { onReset: () => void }) {
     super(props);
     this.state = { hasError: false, error: null, resetCount: 0 };
   }
 
-  static getDerivedStateFromError(error: Error): State {
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     return { hasError: true, error, resetCount: 0 };
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: ErrorBoundaryProps & { onReset: () => void }) {
     if (prevProps.resetKey !== this.props.resetKey && this.state.hasError) {
       this.resetBoundary();
     }
@@ -65,43 +124,80 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   resetBoundary = () => {
-    this.setState((currentState) => ({
-      hasError: false,
-      error: null,
-      resetCount: currentState.resetCount + 1,
-    }));
-  }
+    this.props.onReset();
+    this.setState((s) => ({ hasError: false, error: null, resetCount: s.resetCount + 1 }));
+  };
 
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex min-h-[400px] items-center justify-center p-6">
-          <Card className="w-full max-w-lg border-red-200 shadow-sm">
-            <CardHeader className="items-center text-center">
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-50">
-                <AlertCircle className="h-6 w-6 text-red-500" />
-              </div>
-              <CardTitle>We hit a problem loading this page</CardTitle>
-              <CardDescription>
-                Something unexpected happened. You can try again, and if it keeps happening our team can investigate it.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <p className="rounded-md bg-muted px-4 py-3 text-sm text-muted-foreground">
-                {this.state.error?.message || 'An unexpected error occurred.'}
-              </p>
-            </CardContent>
-            <CardFooter className="justify-center">
-              <Button onClick={this.resetBoundary}>
-                Retry
-              </Button>
-            </CardFooter>
-          </Card>
-        </div>
+        this.props.fallback ?? (
+          <DefaultFallback error={this.state.error} onReset={this.resetBoundary} />
+        )
       );
     }
-
-    return <Fragment key={this.state.resetCount}>{this.props.children}</Fragment>;
+    return (
+      <Fragment key={this.state.resetCount}>
+        <ErrorBoundaryContext.Provider value={{ resetBoundary: this.resetBoundary }}>
+          {this.props.children}
+        </ErrorBoundaryContext.Provider>
+      </Fragment>
+    );
   }
 }
 
+// ─── Public functional wrapper ────────────────────────────────────────────────
+
+export function ErrorBoundary({ children, resetKey, context, fallback }: ErrorBoundaryProps) {
+  const [resetToken, setResetToken] = useState(0);
+  const handleReset = useCallback(() => setResetToken((t) => t + 1), []);
+
+  return (
+    <InternalErrorBoundary
+      key={resetToken}
+      resetKey={resetKey}
+      context={context}
+      fallback={fallback}
+      onReset={handleReset}
+    >
+      {children}
+    </InternalErrorBoundary>
+  );
+}
+
+// ─── withErrorBoundary HOC ────────────────────────────────────────────────────
+
+export function withErrorBoundary<P extends object>(
+  WrappedComponent: React.ComponentType<P>,
+  boundaryProps?: Omit<ErrorBoundaryProps, 'children'>
+) {
+  const displayName = WrappedComponent.displayName ?? WrappedComponent.name ?? 'Component';
+
+  function WithErrorBoundary(props: P) {
+    return (
+      <ErrorBoundary {...boundaryProps}>
+        <WrappedComponent {...props} />
+      </ErrorBoundary>
+    );
+  }
+
+  WithErrorBoundary.displayName = `withErrorBoundary(${displayName})`;
+  return WithErrorBoundary;
+}
+
+// ─── useComponentError hook ───────────────────────────────────────────────────
+
+/**
+ * Lets functional components trigger the nearest error boundary imperatively.
+ * Usage: const { throwError } = useComponentError(); throwError(new Error('oops'));
+ */
+export function useComponentError() {
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (error) throw error;
+  }, [error]);
+
+  const throwError = useCallback((err: Error) => setError(err), []);
+  return { throwError };
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -7,7 +7,9 @@
     "build": "tsc",
     "lint": "echo 'No lint yet'"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@agenticpay/types": "*"
+  },
   "devDependencies": {
     "@agenticpay/typescript-config": "*",
     "@agenticpay/eslint-config": "*",

--- a/packages/contracts/src/exports.ts
+++ b/packages/contracts/src/exports.ts
@@ -1,1 +1,208 @@
-export const contracts = 'contracts';
+import type {
+  Payment,
+  PaymentStatus,
+  PaymentTrigger,
+  Project,
+  ProjectStatus,
+  Milestone,
+  MilestoneStatus,
+  Dispute,
+  DisputeReason,
+  Invoice,
+  Refund,
+  Split,
+  SplitRecipient,
+  PaginationParams,
+  PaginatedResult,
+  ApiError,
+  CurrencyCode,
+  UUID,
+  ISO8601,
+} from '@agenticpay/types';
+
+// Re-export domain types so consumers only need one package
+export type {
+  Payment,
+  PaymentStatus,
+  PaymentTrigger,
+  Project,
+  ProjectStatus,
+  Milestone,
+  MilestoneStatus,
+  Dispute,
+  DisputeReason,
+  Invoice,
+  Refund,
+  Split,
+  SplitRecipient,
+  PaginationParams,
+  PaginatedResult,
+  ApiError,
+  CurrencyCode,
+  UUID,
+  ISO8601,
+};
+
+// ─── Payments API ─────────────────────────────────────────────────────────────
+
+export interface CreatePaymentRequest {
+  from: string;
+  to: string;
+  amount: number;
+  asset: CurrencyCode;
+  trigger: PaymentTrigger;
+  idempotencyKey?: string;
+}
+
+export interface CreatePaymentResponse {
+  data: Payment;
+}
+
+export interface GetPaymentResponse {
+  data: Payment;
+}
+
+export interface ListPaymentsRequest extends PaginationParams {
+  status?: PaymentStatus;
+  from?: string;
+  to?: string;
+}
+
+export interface ListPaymentsResponse {
+  data: PaginatedResult<Payment>;
+}
+
+// ─── Projects API ─────────────────────────────────────────────────────────────
+
+export interface CreateProjectRequest {
+  name: string;
+  clientId: UUID;
+  budget: number;
+  currency: CurrencyCode;
+  startDate: ISO8601;
+  endDate?: ISO8601;
+  description?: string;
+}
+
+export interface CreateProjectResponse {
+  data: Project;
+}
+
+export interface UpdateProjectStatusRequest {
+  status: ProjectStatus;
+}
+
+export interface AddMilestoneRequest {
+  title: string;
+  deliverable: string;
+  amount: number;
+  dueDate: ISO8601;
+}
+
+export interface AddMilestoneResponse {
+  data: Milestone;
+}
+
+export interface UpdateMilestoneStatusRequest {
+  status: MilestoneStatus;
+  submissionUrl?: string;
+  submissionNotes?: string;
+  disputeReason?: string;
+}
+
+// ─── Disputes API ─────────────────────────────────────────────────────────────
+
+export interface RaiseDisputeRequest {
+  projectId: UUID;
+  reason: DisputeReason;
+  description?: string;
+}
+
+export interface RaiseDisputeResponse {
+  data: Dispute;
+}
+
+export interface ResolveDisputeRequest {
+  outcome: 'full_refund' | 'partial_refund' | 'release_to_payee' | 'dismissed';
+  notes?: string;
+}
+
+// ─── Invoices API ─────────────────────────────────────────────────────────────
+
+export interface CreateInvoiceRequest {
+  projectId: UUID;
+  amount: number;
+  currency: CurrencyCode;
+  dueDate: ISO8601;
+}
+
+export interface CreateInvoiceResponse {
+  data: Invoice;
+}
+
+// ─── Refunds API ──────────────────────────────────────────────────────────────
+
+export interface RequestRefundRequest {
+  paymentId: UUID;
+  amount: number;
+  reason: string;
+}
+
+export interface RequestRefundResponse {
+  data: Refund;
+}
+
+// ─── Splits API ───────────────────────────────────────────────────────────────
+
+export interface CreateSplitRequest {
+  paymentId: UUID;
+  recipients: SplitRecipient[];
+}
+
+export interface CreateSplitResponse {
+  data: Split;
+}
+
+// ─── Auth API ─────────────────────────────────────────────────────────────────
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}
+
+export interface RefreshTokenRequest {
+  refreshToken: string;
+}
+
+export interface RefreshTokenResponse {
+  accessToken: string;
+  expiresIn: number;
+}
+
+// ─── Webhook events ───────────────────────────────────────────────────────────
+
+export type WebhookEventType =
+  | 'payment.created'
+  | 'payment.executed'
+  | 'payment.failed'
+  | 'payment.cancelled'
+  | 'project.created'
+  | 'project.funded'
+  | 'project.completed'
+  | 'project.disputed'
+  | 'invoice.generated'
+  | 'refund.requested'
+  | 'refund.approved';
+
+export interface WebhookPayload<T = unknown> {
+  id: UUID;
+  type: WebhookEventType;
+  createdAt: ISO8601;
+  data: T;
+}

--- a/packages/types/src/exports.ts
+++ b/packages/types/src/exports.ts
@@ -1,1 +1,207 @@
-export const types = 'types';
+// ─── Common primitives ────────────────────────────────────────────────────────
+
+export type ISO8601 = string;
+export type UUID = string;
+export type CurrencyCode = string; // e.g. "USD", "USDC", "XLM"
+
+// ─── Domain: Payments ─────────────────────────────────────────────────────────
+
+export type PaymentStatus = 'pending' | 'executed' | 'failed' | 'cancelled';
+
+export type PaymentTriggerType = 'immediate' | 'scheduled' | 'conditional';
+
+export interface PaymentTrigger {
+  type: PaymentTriggerType;
+  executeAt?: ISO8601;
+  condition?: string;
+}
+
+export interface Payment {
+  id: UUID;
+  from: string;
+  to: string;
+  amount: number;
+  asset: CurrencyCode;
+  status: PaymentStatus;
+  trigger: PaymentTrigger;
+  createdAt: ISO8601;
+  updatedAt: ISO8601;
+}
+
+// ─── Domain: Projects ─────────────────────────────────────────────────────────
+
+export type ProjectStatus = 'active' | 'completed' | 'archived' | 'disputed' | 'abandoned';
+
+export type MilestoneStatus =
+  | 'pending'
+  | 'submitted'
+  | 'approved'
+  | 'released'
+  | 'disputed';
+
+export interface Milestone {
+  id: UUID;
+  title: string;
+  deliverable: string;
+  amount: number;
+  dueDate: ISO8601;
+  status: MilestoneStatus;
+  submittedAt: ISO8601 | null;
+  approvedAt: ISO8601 | null;
+  submissionUrl: string | null;
+  submissionNotes: string | null;
+  disputeReason: string | null;
+  createdAt: ISO8601;
+  updatedAt: ISO8601;
+}
+
+export interface Project {
+  id: UUID;
+  name: string;
+  clientId: UUID;
+  ownerId: UUID;
+  budget: number;
+  spentBudget: number;
+  currency: CurrencyCode;
+  startDate: ISO8601;
+  endDate: ISO8601 | null;
+  description?: string;
+  status: ProjectStatus;
+  archivedAt: ISO8601 | null;
+  createdAt: ISO8601;
+  updatedAt: ISO8601;
+  scopeChangeCount: number;
+}
+
+// ─── Domain: Disputes ─────────────────────────────────────────────────────────
+
+export type DisputeStatus =
+  | 'pending'
+  | 'awaiting_response'
+  | 'under_review'
+  | 'resolved'
+  | 'escalated'
+  | 'dismissed';
+
+export type DisputeReason =
+  | 'service_not_delivered'
+  | 'partial_delivery'
+  | 'quality_issue'
+  | 'unauthorized_charge'
+  | 'duplicate_charge'
+  | 'other';
+
+export type ResolutionOutcome =
+  | 'full_refund'
+  | 'partial_refund'
+  | 'release_to_payee'
+  | 'dismissed'
+  | 'pending';
+
+export interface Dispute {
+  id: UUID;
+  projectId: UUID;
+  raisedBy: UUID;
+  reason: DisputeReason;
+  status: DisputeStatus;
+  outcome: ResolutionOutcome | null;
+  createdAt: ISO8601;
+  updatedAt: ISO8601;
+}
+
+// ─── Domain: Users / Auth ────────────────────────────────────────────────────
+
+export interface User {
+  id: UUID;
+  email: string;
+  displayName?: string;
+  role: UserRole;
+  createdAt: ISO8601;
+  updatedAt: ISO8601;
+}
+
+export type UserRole = 'client' | 'freelancer' | 'admin';
+
+// ─── Domain: Invoices ─────────────────────────────────────────────────────────
+
+export type InvoiceStatus = 'draft' | 'sent' | 'paid' | 'overdue' | 'cancelled';
+
+export interface Invoice {
+  id: UUID;
+  projectId: UUID;
+  clientId: UUID;
+  freelancerId: UUID;
+  amount: number;
+  currency: CurrencyCode;
+  status: InvoiceStatus;
+  dueDate: ISO8601;
+  issuedAt: ISO8601;
+  paidAt: ISO8601 | null;
+}
+
+// ─── Domain: Receipts ────────────────────────────────────────────────────────
+
+export interface Receipt {
+  tokenId: string;
+  paymentId: UUID;
+  sender: string;
+  recipient: string;
+  amount: number;
+  asset: CurrencyCode;
+  mintedAt: ISO8601;
+}
+
+// ─── Domain: Refunds ─────────────────────────────────────────────────────────
+
+export type RefundStatus = 'requested' | 'approved' | 'rejected' | 'processed';
+
+export interface Refund {
+  id: UUID;
+  paymentId: UUID;
+  amount: number;
+  currency: CurrencyCode;
+  status: RefundStatus;
+  reason: string;
+  requestedAt: ISO8601;
+  resolvedAt: ISO8601 | null;
+}
+
+// ─── Domain: Splits ──────────────────────────────────────────────────────────
+
+export interface SplitRecipient {
+  address: string;
+  basisPoints: number; // out of 10_000
+}
+
+export interface Split {
+  id: UUID;
+  paymentId: UUID;
+  recipients: SplitRecipient[];
+  status: 'created' | 'executed';
+  createdAt: ISO8601;
+}
+
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+export interface PaginationParams {
+  page?: number;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+// ─── Error envelope ──────────────────────────────────────────────────────────
+
+export interface ApiError {
+  error: string;
+  message: string;
+  statusCode: number;
+  details?: Record<string, unknown>;
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "@agenticpay/typescript-config/base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
   },
   "include": [
     "src"


### PR DESCRIPTION
## Summary

Resolves four open issues in one combined PR:

### #391 — Add idempotency key support for payment operations
- Accepts both standard `Idempotency-Key` and legacy `X-Idempotency-Key` request headers
- **Collision detection**: concurrent requests with the same key receive a `409 Conflict` instead of racing each other
- **Selective caching**: only 2xx/4xx responses are cached; transient 5xx are not, so failed operations can be retried with the same key
- **Key lifecycle**: `purgeExpiredIdempotencyKeys()` utility for scheduled cleanup; `getIdempotencyCacheStats()` for monitoring
- Key length validation (max 255 chars, returns 400 on violation)

### #373 — Refactor frontend components from class-based to functional with hooks
- `ErrorBoundary` is now a **functional wrapper** — the internal class is kept because React requires a class component for `getDerivedStateFromError`, but all public API is functional
- `useErrorBoundary()` hook — lets any functional child access `resetBoundary()` via React context
- `withErrorBoundary()` HOC — wraps any component with error boundary protection declaratively
- `useComponentError()` hook — lets functional components imperatively trigger the nearest boundary
- `DefaultFallback` extracted as a standalone functional component

### #372 — Refactor service layer to use event-driven architecture
- `dead-letter-queue.ts` — captures every handler failure with event snapshot, handler name, error message, retry count, and resolution state; includes `purgeResolvedEntries()` for memory management
- `idempotent-handler.ts` — `idempotentHandler()` wrapper ensures each event `id` is processed at most once (duplicate deliveries are silently dropped)
- `event-bus.ts` updated — handler exceptions are now caught and routed to the DLQ instead of crashing the publisher, making `publish()` resilient to individual handler failures
- `index.ts` barrel added so all event utilities are importable from a single path

### #371 — Refactor TypeScript types to shared packages with strict mode
- `packages/types` populated with **domain model types**: `Payment`, `Project`, `Milestone`, `Dispute`, `Invoice`, `Receipt`, `Refund`, `Split`, `User`, plus `PaginatedResult`, `ApiError`, and primitive aliases (`UUID`, `ISO8601`, `CurrencyCode`)
- `packages/contracts` populated with **full API contract types** — request/response shapes for Payments, Projects, Disputes, Invoices, Refunds, Splits, Auth, and Webhook payload envelopes; re-exports all domain types so consumers only need one import
- `@agenticpay/types` added as a dependency of `@agenticpay/contracts`
- `packages/types/tsconfig.json` upgraded with `strictNullChecks: true`, `noUncheckedIndexedAccess: true`, and `exactOptionalPropertyTypes: true`

## Files changed

| File | Issue |
|---|---|
| `backend/src/middleware/idempotency.ts` + `.js` | #391 |
| `frontend/components/errors/ErrorBoundary.tsx` | #373 |
| `backend/src/events/event-bus.ts` | #372 |
| `backend/src/events/dead-letter-queue.ts` *(new)* | #372 |
| `backend/src/events/idempotent-handler.ts` *(new)* | #372 |
| `backend/src/events/index.ts` *(new)* | #372 |
| `packages/types/src/exports.ts` | #371 |
| `packages/types/tsconfig.json` | #371 |
| `packages/contracts/src/exports.ts` | #371 |
| `packages/contracts/package.json` | #371 |

## Test plan
- [ ] Send duplicate payment requests with same `Idempotency-Key` — second should return cached response, concurrent should return 409
- [ ] Send request with `Idempotency-Key` longer than 255 chars — should return 400
- [ ] Trigger an error inside a component wrapped with `<ErrorBoundary>` — fallback UI should render; clicking Retry should reset
- [ ] Call `useErrorBoundary().resetBoundary()` from a child component — boundary should reset
- [ ] Publish an event where a handler throws — error should be logged and entry should appear in `getDeadLetterQueue()`
- [ ] Subscribe with `idempotentHandler()` and publish the same event twice — handler should execute only once
- [ ] Import types from `@agenticpay/types` and `@agenticpay/contracts` — TypeScript should resolve all types with strict mode

Closes #371
Closes #372
Closes #373
Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)