### PR TITLE
feat: resolve #386 #387 #388 #400 — Redis eviction, HTTP/2 push, WS p…

### DIFF
--- a/backend/src/middleware/cache.ts
+++ b/backend/src/middleware/cache.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { Request, Response, NextFunction } from 'express';
+import Redis from 'ioredis';
 
 export interface CacheOptions {
   maxAge: number;
@@ -153,15 +154,29 @@ class CacheMonitor {
 }
 
 class RedisCache {
+  private client: Redis | null = null;
   private enabled = false;
 
   async connect(): Promise<void> {
+    const url = process.env.REDIS_URL;
+    if (!url) return;
+
     try {
-      const env = process.env.REDIS_URL || process.env.REDIS_ENABLED;
-      if (env) {
-        this.enabled = true;
-      }
+      this.client = new Redis(url, {
+        lazyConnect: true,
+        maxRetriesPerRequest: 3,
+        retryStrategy: (times) => Math.min(times * 200, 2000),
+      });
+      await this.client.connect();
+
+      // Configure optimal eviction policy and memory limit
+      const memoryLimit = process.env.REDIS_MEMORY_LIMIT ?? '256mb';
+      await this.client.config('SET', 'maxmemory', memoryLimit);
+      await this.client.config('SET', 'maxmemory-policy', 'allkeys-lru');
+
+      this.enabled = true;
     } catch {
+      this.client = null;
       this.enabled = false;
     }
   }
@@ -171,19 +186,55 @@ class RedisCache {
   }
 
   async get<T>(key: string): Promise<T | null> {
-    if (!this.enabled) return null;
-    return null;
+    if (!this.client || !this.enabled) return null;
+    try {
+      const raw = await this.client.get(key);
+      return raw ? (JSON.parse(raw) as T) : null;
+    } catch {
+      return null;
+    }
   }
 
   async set(key: string, value: unknown, ttlMs: number): Promise<void> {
+    if (!this.client || !this.enabled) return;
+    const ttlSec = Math.max(1, Math.ceil(ttlMs / 1000));
+    try {
+      await this.client.setex(key, ttlSec, JSON.stringify(value));
+    } catch { /* non-fatal */ }
   }
 
   async invalidate(pattern: string): Promise<void> {
-    if (!this.enabled) return;
+    if (!this.client || !this.enabled) return;
+    try {
+      const keys = await this.client.keys(pattern);
+      if (keys.length > 0) await this.client.del(...keys);
+    } catch { /* non-fatal */ }
   }
 
   async invalidateAll(): Promise<void> {
-    if (!this.enabled) return;
+    if (!this.client || !this.enabled) return;
+    try {
+      await this.client.flushdb();
+    } catch { /* non-fatal */ }
+  }
+
+  /** Returns Redis memory usage and server-side hit ratio for monitoring. */
+  async getMemoryInfo(): Promise<{ usedMemory: string; maxMemory: string; hitRatio: number } | null> {
+    if (!this.client || !this.enabled) return null;
+    try {
+      const [memInfo, statsInfo] = await Promise.all([
+        this.client.info('memory'),
+        this.client.info('stats'),
+      ]);
+      const usedMemory = memInfo.match(/used_memory_human:(.+)/)?.[1]?.trim() ?? '?';
+      const maxMemory = memInfo.match(/maxmemory_human:(.+)/)?.[1]?.trim() ?? '?';
+      const hits = Number(statsInfo.match(/keyspace_hits:(\d+)/)?.[1] ?? 0);
+      const misses = Number(statsInfo.match(/keyspace_misses:(\d+)/)?.[1] ?? 0);
+      const hitRatio = hits + misses > 0 ? hits / (hits + misses) : 0;
+      return { usedMemory, maxMemory, hitRatio };
+    } catch {
+      return null;
+    }
   }
 }
 

--- a/backend/src/middleware/internalSignature.ts
+++ b/backend/src/middleware/internalSignature.ts
@@ -1,0 +1,152 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { auditService } from '../services/auditService.js';
+
+const REPLAY_WINDOW_MS = 5 * 60 * 1000; // 5-minute window
+const SIG_ALGO = 'sha256';
+
+export const HEADER_SIGNATURE = 'x-internal-signature';
+export const HEADER_TIMESTAMP = 'x-internal-timestamp';
+export const HEADER_KEY_ID = 'x-internal-key-id';
+
+interface SigningKey {
+  id: string;
+  secret: string;
+  /** Unix ms — key not valid before this time */
+  validFrom: number;
+  /** Unix ms — key not valid at or after this time (absent = no expiry) */
+  validUntil?: number;
+}
+
+const signingKeys = new Map<string, SigningKey>();
+/** Replay-prevention: maps `keyId:timestamp:sig` → request timestamp */
+const usedTokens = new Map<string, number>();
+
+export function addSigningKey(key: SigningKey): void {
+  signingKeys.set(key.id, key);
+}
+
+export function removeSigningKey(id: string): void {
+  signingKeys.delete(id);
+}
+
+/** Load keys from INTERNAL_API_SIGNING_KEYS env var (JSON array of SigningKey).
+ *  Falls back to a single key from INTERNAL_API_SECRET (or a generated dev secret). */
+export function initSigningKeys(): void {
+  const raw = process.env.INTERNAL_API_SIGNING_KEYS;
+  if (raw) {
+    try {
+      const keys = JSON.parse(raw) as SigningKey[];
+      for (const k of keys) addSigningKey(k);
+      return;
+    } catch { /* fall through to single-key fallback */ }
+  }
+  addSigningKey({
+    id: 'default',
+    secret: process.env.INTERNAL_API_SECRET ?? randomBytes(32).toString('hex'),
+    validFrom: 0,
+  });
+}
+
+function buildPayload(method: string, url: string, timestamp: string, body: string): string {
+  return `${method.toUpperCase()}\n${url}\n${timestamp}\n${body}`;
+}
+
+function computeHmac(secret: string, data: string): string {
+  return createHmac(SIG_ALGO, secret).update(data, 'utf8').digest('hex');
+}
+
+/** Returns headers to attach when calling an internal service. */
+export function signRequest(params: {
+  method: string;
+  url: string;
+  body?: unknown;
+  keyId?: string;
+}): Record<string, string> {
+  const keyId = params.keyId ?? [...signingKeys.keys()][0];
+  if (!keyId) throw new Error('No internal signing key configured');
+  const key = signingKeys.get(keyId);
+  if (!key) throw new Error(`Unknown signing key: ${keyId}`);
+
+  const timestamp = Date.now().toString();
+  const bodyStr = params.body !== undefined ? JSON.stringify(params.body) : '';
+  const signature = computeHmac(key.secret, buildPayload(params.method, params.url, timestamp, bodyStr));
+
+  return {
+    [HEADER_KEY_ID]: keyId,
+    [HEADER_TIMESTAMP]: timestamp,
+    [HEADER_SIGNATURE]: signature,
+  };
+}
+
+// Evict expired replay tokens every minute
+setInterval(() => {
+  const cutoff = Date.now() - REPLAY_WINDOW_MS;
+  for (const [k, ts] of usedTokens) {
+    if (ts < cutoff) usedTokens.delete(k);
+  }
+}, 60_000);
+
+/** Express middleware — rejects requests without a valid HMAC signature. */
+export function verifyInternalSignature(req: Request, res: Response, next: NextFunction): void {
+  const keyId = req.headers[HEADER_KEY_ID] as string | undefined;
+  const timestamp = req.headers[HEADER_TIMESTAMP] as string | undefined;
+  const signature = req.headers[HEADER_SIGNATURE] as string | undefined;
+
+  if (!keyId || !timestamp || !signature) {
+    res.status(401).json({ error: 'Missing internal signature headers' });
+    return;
+  }
+
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts) || Math.abs(Date.now() - ts) > REPLAY_WINDOW_MS) {
+    void auditService.logAction({ action: 'internal_api.auth.failed', resource: 'internal_api', details: { reason: 'timestamp_out_of_window', keyId } });
+    res.status(401).json({ error: 'Request timestamp outside acceptable window' });
+    return;
+  }
+
+  const replayToken = `${keyId}:${timestamp}:${signature}`;
+  if (usedTokens.has(replayToken)) {
+    void auditService.logAction({ action: 'internal_api.auth.failed', resource: 'internal_api', details: { reason: 'replay_detected', keyId } });
+    res.status(401).json({ error: 'Replay detected' });
+    return;
+  }
+
+  const key = signingKeys.get(keyId);
+  if (!key) {
+    void auditService.logAction({ action: 'internal_api.auth.failed', resource: 'internal_api', details: { reason: 'unknown_key', keyId } });
+    res.status(401).json({ error: 'Unknown key ID' });
+    return;
+  }
+
+  const now = Date.now();
+  if (now < key.validFrom || (key.validUntil !== undefined && now >= key.validUntil)) {
+    void auditService.logAction({ action: 'internal_api.auth.failed', resource: 'internal_api', details: { reason: 'key_expired', keyId } });
+    res.status(401).json({ error: 'Signing key not valid at this time' });
+    return;
+  }
+
+  const bodyStr = req.body !== undefined ? JSON.stringify(req.body) : '';
+  const expected = computeHmac(key.secret, buildPayload(req.method, req.originalUrl, timestamp, bodyStr));
+
+  let valid = false;
+  try {
+    const sigBuf = Buffer.from(signature, 'hex');
+    const expBuf = Buffer.from(expected, 'hex');
+    valid = sigBuf.length === expBuf.length && timingSafeEqual(sigBuf, expBuf);
+  } catch { /* invalid hex in signature */ }
+
+  if (!valid) {
+    void auditService.logAction({ action: 'internal_api.auth.failed', resource: 'internal_api', details: { reason: 'invalid_signature', keyId } });
+    res.status(401).json({ error: 'Invalid signature' });
+    return;
+  }
+
+  usedTokens.set(replayToken, ts);
+  void auditService.logAction({
+    action: 'internal_api.auth.success',
+    resource: 'internal_api',
+    details: { keyId, method: req.method, url: req.originalUrl },
+  });
+  next();
+}

--- a/backend/src/websocket/codec.ts
+++ b/backend/src/websocket/codec.ts
@@ -1,0 +1,129 @@
+/**
+ * Minimal protobuf-compatible binary codec for WebSocket wire messages.
+ * Implements the schema defined in packages/types/src/websocket.proto.
+ * No external dependencies — encodes/decodes using the protobuf binary format
+ * spec so messages are interoperable with any standard protobuf decoder.
+ */
+import type { WebSocketWireMessage } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Protobuf primitives
+// ---------------------------------------------------------------------------
+
+function writeVarint(out: number[], value: number): void {
+  let v = value >>> 0;
+  while (v > 0x7f) {
+    out.push((v & 0x7f) | 0x80);
+    v >>>= 7;
+  }
+  out.push(v);
+}
+
+function readVarint(buf: Uint8Array, pos: { offset: number }): number {
+  let result = 0;
+  let shift = 0;
+  while (pos.offset < buf.length) {
+    const byte = buf[pos.offset++];
+    result |= (byte & 0x7f) << shift;
+    if (!(byte & 0x80)) break;
+    shift += 7;
+  }
+  return result >>> 0;
+}
+
+// wire types
+const VARINT = 0;
+const LEN = 2;
+
+function tag(field: number, wireType: number): number {
+  return (field << 3) | wireType;
+}
+
+function encodeString(out: number[], field: number, value: string): void {
+  if (!value) return;
+  const encoded = Buffer.from(value, 'utf8');
+  writeVarint(out, tag(field, LEN));
+  writeVarint(out, encoded.length);
+  for (const b of encoded) out.push(b);
+}
+
+function encodeUint32(out: number[], field: number, value: number): void {
+  if (value === 0) return;
+  writeVarint(out, tag(field, VARINT));
+  writeVarint(out, value);
+}
+
+function encodeBytes(out: number[], field: number, value: Buffer): void {
+  if (value.length === 0) return;
+  writeVarint(out, tag(field, LEN));
+  writeVarint(out, value.length);
+  for (const b of value) out.push(b);
+}
+
+// ---------------------------------------------------------------------------
+// WireMessage encoder (fields match websocket.proto)
+// ---------------------------------------------------------------------------
+
+export function encodeWireMessage(msg: WebSocketWireMessage): Buffer {
+  const out: number[] = [];
+  encodeString(out, 1, msg.type);
+  if (msg.channel) encodeString(out, 2, msg.channel);
+  encodeUint32(out, 3, msg.sequence);
+  encodeString(out, 4, msg.sessionId);
+  encodeString(out, 5, msg.emittedAt);
+  if (msg.payload !== undefined) {
+    encodeBytes(out, 6, Buffer.from(JSON.stringify(msg.payload), 'utf8'));
+  }
+  return Buffer.from(out);
+}
+
+// ---------------------------------------------------------------------------
+// WireMessageBatch encoder — always wraps messages in repeated field 1
+// ---------------------------------------------------------------------------
+
+export function encodeBatch(msgs: WebSocketWireMessage[]): Buffer {
+  const out: number[] = [];
+  for (const msg of msgs) {
+    const encoded = encodeWireMessage(msg);
+    writeVarint(out, tag(1, LEN));
+    writeVarint(out, encoded.length);
+    for (const b of encoded) out.push(b);
+  }
+  return Buffer.from(out);
+}
+
+// ---------------------------------------------------------------------------
+// ClientMessage decoder (server receives from binary-mode clients)
+// ---------------------------------------------------------------------------
+
+export function decodeClientMessage(
+  data: Buffer,
+): { type: string; channels: string[]; expiresAt?: string } | null {
+  try {
+    const pos = { offset: 0 };
+    let type: string | undefined;
+    const channels: string[] = [];
+    let expiresAt: string | undefined;
+
+    while (pos.offset < data.length) {
+      const t = readVarint(data, pos);
+      const fieldNumber = t >>> 3;
+      const wireType = t & 0x7;
+      if (wireType === LEN) {
+        const len = readVarint(data, pos);
+        const str = data.slice(pos.offset, pos.offset + len).toString('utf8');
+        pos.offset += len;
+        if (fieldNumber === 1) type = str;
+        else if (fieldNumber === 2) channels.push(str);
+        else if (fieldNumber === 3) expiresAt = str;
+      } else {
+        break; // unsupported wire type — stop parsing
+      }
+    }
+
+    if (!type) return null;
+    return { type, channels, expiresAt };
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/websocket/managedConnection.ts
+++ b/backend/src/websocket/managedConnection.ts
@@ -6,8 +6,9 @@ import type {
   WebSocketServerMetrics,
   WebSocketWireMessage,
 } from './types.js';
+import { encodeBatch } from './codec.js';
 
-type QueueItem = { json: string; priority: 'high' | 'normal' };
+type QueueItem = { message: WebSocketWireMessage; priority: 'high' | 'normal' };
 
 export class ManagedConnection {
   readonly sessionId = randomUUID();
@@ -16,6 +17,7 @@ export class ManagedConnection {
   private readonly maxQueueSize: number;
   private readonly maxBufferedAmountBytes: number;
   private readonly maxBatchSize: number;
+  private readonly useBinary: boolean;
   private readonly queueHigh: QueueItem[] = [];
   private readonly queueNormal: QueueItem[] = [];
   private readonly channels = new Set<WebSocketChannel>();
@@ -30,12 +32,14 @@ export class ManagedConnection {
     maxBatchSize: number;
     defaultChannels: WebSocketChannel[];
     authExpiresAtMs?: number;
+    useBinary?: boolean;
   }) {
     this.ws = params.ws;
     this.metrics = params.metrics;
     this.maxQueueSize = params.maxQueueSize;
     this.maxBufferedAmountBytes = params.maxBufferedAmountBytes;
     this.maxBatchSize = params.maxBatchSize;
+    this.useBinary = params.useBinary ?? false;
     this.authExpiresAtMs = params.authExpiresAtMs;
 
     for (const channel of params.defaultChannels) {
@@ -57,7 +61,6 @@ export class ManagedConnection {
       sequence: ++this.sequence,
       emittedAt: new Date().toISOString(),
     };
-    const json = JSON.stringify(wireMessage);
 
     const totalSize = this.queueHigh.length + this.queueNormal.length;
     if (totalSize >= this.maxQueueSize) {
@@ -65,7 +68,7 @@ export class ManagedConnection {
       return { accepted: false, reason: 'QUEUE_FULL' };
     }
 
-    const item: QueueItem = { json, priority };
+    const item: QueueItem = { message: wireMessage, priority };
     if (priority === 'high') {
       this.queueHigh.push(item);
     } else {
@@ -111,19 +114,25 @@ export class ManagedConnection {
     if (this.ws.readyState !== this.ws.OPEN) return;
     if (this.ws.bufferedAmount > this.maxBufferedAmountBytes) return;
 
-    const batch: string[] = [];
+    const batch: QueueItem[] = [];
     while (batch.length < this.maxBatchSize) {
       const next = this.queueHigh.shift() ?? this.queueNormal.shift();
       if (!next) break;
-      batch.push(next.json);
+      batch.push(next);
     }
 
     if (batch.length === 0) return;
 
-    // A single frame keeps slow clients from amplifying CPU overhead.
-    const payload = batch.length === 1 ? batch[0] : `[${batch.join(',')}]`;
-    this.ws.send(payload);
-    this.metrics.sentMessages += batch.length;
+    const messages = batch.map((i) => i.message);
+    if (this.useBinary) {
+      // Binary protobuf frame — WireMessageBatch encoding
+      this.ws.send(encodeBatch(messages));
+    } else {
+      // Text JSON frame — compatible with all clients
+      const strs = messages.map((m) => JSON.stringify(m));
+      this.ws.send(strs.length === 1 ? strs[0] : `[${strs.join(',')}]`);
+    }
+    this.metrics.sentMessages += messages.length;
   }
 
   getQueuedCount(): number {

--- a/backend/src/websocket/server.ts
+++ b/backend/src/websocket/server.ts
@@ -66,6 +66,7 @@ export function attachWebSocketServer(params: {
     pongTimeoutMs: 10_000,
     defaultChannels: ['payment.events', 'dispute.updates', 'analytics.updates'],
     maxAuthAgeMs: 60 * 60 * 1000,
+    enableBinaryProtocol: true,
     ...params.options,
   };
 
@@ -109,6 +110,7 @@ export function attachWebSocketServer(params: {
       maxBatchSize: options.maxBatchSize,
       defaultChannels: options.defaultChannels,
       authExpiresAtMs: parseAuthExpiry(url.searchParams.get('expiresAt'), options.maxAuthAgeMs),
+      useBinary: options.enableBinaryProtocol && url.searchParams.get('proto') === '1',
     });
 
     connections.set(ws, managed);

--- a/backend/src/websocket/types.ts
+++ b/backend/src/websocket/types.ts
@@ -43,4 +43,6 @@ export type WebSocketServerOptions = {
   pongTimeoutMs: number;
   defaultChannels: WebSocketChannel[];
   maxAuthAgeMs: number;
+  /** When true, clients that opt in via ?proto=1 receive binary protobuf frames instead of JSON. */
+  enableBinaryProtocol?: boolean;
 };

--- a/frontend/lib/websocket/codec.ts
+++ b/frontend/lib/websocket/codec.ts
@@ -1,0 +1,97 @@
+/**
+ * Browser-side protobuf decoder for WebSocket binary frames.
+ * Mirrors the schema in packages/types/src/websocket.proto and the
+ * backend codec at backend/src/websocket/codec.ts.
+ * Uses only browser-native APIs (TextDecoder, Uint8Array) — no deps.
+ */
+
+export type DecodedWireMessage = {
+  type: string;
+  channel?: string;
+  sequence?: number;
+  sessionId?: string;
+  emittedAt?: string;
+  payload?: unknown;
+};
+
+// ---------------------------------------------------------------------------
+// Protobuf primitives
+// ---------------------------------------------------------------------------
+
+function readVarint(buf: Uint8Array, pos: { offset: number }): number {
+  let result = 0;
+  let shift = 0;
+  while (pos.offset < buf.length) {
+    const byte = buf[pos.offset++];
+    result |= (byte & 0x7f) << shift;
+    if (!(byte & 0x80)) break;
+    shift += 7;
+  }
+  return result >>> 0;
+}
+
+const dec = new TextDecoder();
+
+function decodeWireMessage(buf: Uint8Array): DecodedWireMessage {
+  const pos = { offset: 0 };
+  const msg: DecodedWireMessage = { type: '' };
+
+  while (pos.offset < buf.length) {
+    const t = readVarint(buf, pos);
+    const fieldNumber = t >>> 3;
+    const wireType = t & 0x7;
+
+    if (wireType === 2) {
+      // LEN — string, bytes, or embedded message
+      const len = readVarint(buf, pos);
+      const bytes = buf.slice(pos.offset, pos.offset + len);
+      pos.offset += len;
+      const str = dec.decode(bytes);
+      if (fieldNumber === 1) msg.type = str;
+      else if (fieldNumber === 2) msg.channel = str;
+      else if (fieldNumber === 4) msg.sessionId = str;
+      else if (fieldNumber === 5) msg.emittedAt = str;
+      else if (fieldNumber === 6) {
+        try { msg.payload = JSON.parse(str); } catch { msg.payload = str; }
+      }
+    } else if (wireType === 0) {
+      // VARINT
+      const val = readVarint(buf, pos);
+      if (fieldNumber === 3) msg.sequence = val;
+    } else {
+      break; // unexpected wire type — stop
+    }
+  }
+  return msg;
+}
+
+// ---------------------------------------------------------------------------
+// Public API — decodes a WireMessageBatch binary frame
+// ---------------------------------------------------------------------------
+
+/**
+ * Decodes an ArrayBuffer received from the server when binary protocol is active.
+ * The server always encodes as WireMessageBatch (repeated field 1 = WireMessage).
+ */
+export function decodeServerBinary(data: ArrayBuffer): DecodedWireMessage[] {
+  const buf = new Uint8Array(data);
+  const messages: DecodedWireMessage[] = [];
+  const pos = { offset: 0 };
+
+  while (pos.offset < buf.length) {
+    const t = readVarint(buf, pos);
+    const fieldNumber = t >>> 3;
+    const wireType = t & 0x7;
+
+    if (wireType === 2 && fieldNumber === 1) {
+      const len = readVarint(buf, pos);
+      const msgBuf = buf.slice(pos.offset, pos.offset + len);
+      pos.offset += len;
+      messages.push(decodeWireMessage(msgBuf));
+    } else {
+      break;
+    }
+  }
+
+  return messages;
+}

--- a/frontend/lib/websocket/pool.ts
+++ b/frontend/lib/websocket/pool.ts
@@ -21,6 +21,8 @@ type PoolState = {
   droppedMessages?: number;
 };
 
+import { decodeServerBinary } from "./codec.js";
+
 type OutboundItem = { data: string; priority: "high" | "normal" };
 type WireMessage = {
   type: string;
@@ -75,7 +77,9 @@ export class WebSocketPool {
     if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) return;
 
     this.setState({ connected: false, reconnecting: this.reconnectAttempt > 0 });
+    const useBinary = this.options.url.includes("proto=1");
     const ws = new WebSocket(this.options.url);
+    if (useBinary) ws.binaryType = "arraybuffer";
     this.ws = ws;
 
     ws.onopen = () => {
@@ -88,8 +92,17 @@ export class WebSocketPool {
     };
 
     ws.onmessage = (event) => {
-      const data = typeof event.data === "string" ? event.data : "";
-      this.deliverOrdered(data);
+      if (event.data instanceof ArrayBuffer) {
+        // Binary protobuf frame — decode and re-serialize for existing ordered delivery
+        const messages = decodeServerBinary(event.data);
+        const json = messages.length === 1
+          ? JSON.stringify(messages[0])
+          : JSON.stringify(messages);
+        this.deliverOrdered(json);
+      } else {
+        const data = typeof event.data === "string" ? event.data : "";
+        this.deliverOrdered(data);
+      }
     };
 
     ws.onerror = () => {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -114,6 +114,21 @@ const nextConfig: NextConfig = {
   headers: async () => {
     return [
       {
+        // HTTP/2 server push hints for critical assets on every page load
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Link",
+            value: [
+              // Critical fonts — pushed before HTML is parsed
+              "</fonts/inter-var.woff2>; rel=preload; as=font; type=\"font/woff2\"; crossorigin=anonymous",
+              // Critical CSS — pushed alongside the document
+              "</_next/static/css/app/layout.css>; rel=preload; as=style",
+            ].join(", "),
+          },
+        ],
+      },
+      {
         source: "/:path*.js",
         headers: [
           {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -298,6 +298,20 @@ resource "aws_amplify_app" "frontend" {
   name       = "agenticpay-frontend-${var.environment}"
   repository = "https://github.com/Smartdevs17/agenticpay"
 
+  # HTTP/2 is enabled by default on AWS Amplify (ALPN negotiation via CloudFront).
+  # custom_headers propagates Link preload hints so CloudFront can issue
+  # HTTP/2 PUSH_PROMISE frames for critical fonts and CSS before the HTML
+  # has been parsed by the browser.
+  custom_headers = <<-EOT
+    customHeaders:
+      - pattern: '**'
+        headers:
+          - key: 'X-Frame-Options'
+            value: 'SAMEORIGIN'
+          - key: 'Link'
+            value: '</fonts/inter-var.woff2>; rel=preload; as=font; type="font/woff2"; crossorigin=anonymous'
+  EOT
+
   build_spec = <<-EOT
     version: 1
     frontend:

--- a/packages/types/src/websocket.proto
+++ b/packages/types/src/websocket.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+package agenticpay.websocket;
+
+// Server → client: a single event frame
+message WireMessage {
+  string type       = 1; // event type, e.g. "payment.created"
+  string channel    = 2; // subscription channel
+  uint32 sequence   = 3; // monotonic per-session sequence number
+  string session_id = 4;
+  string emitted_at = 5; // ISO-8601 timestamp
+  bytes  payload    = 6; // JSON-encoded event payload
+}
+
+// Server → client: a batch of WireMessages in one binary frame
+message WireMessageBatch {
+  repeated WireMessage messages = 1;
+}
+
+// Client → server: control message (subscribe / unsubscribe / auth.refresh / ping)
+message ClientMessage {
+  string          type       = 1;
+  repeated string channels   = 2;
+  string          expires_at = 3;
+}


### PR DESCRIPTION
…rotobuf, internal signing

Closes #386  — Redis cache eviction policy
- Implement real ioredis connection in RedisCache (was a stub)
- Set maxmemory-policy allkeys-lru and configurable maxmemory on connect
- Add TTL to every cache entry via setex; add getMemoryInfo() for monitoring

Closes #387  — HTTP/2 server push and connection multiplexing
- Add Link preload headers for critical fonts and CSS in next.config.ts so HTTP/2-aware proxies issue PUSH_PROMISE frames before HTML is parsed
- Add custom_headers to aws_amplify_app in infra/main.tf to propagate server push hints through CloudFront (HTTP/2 enabled by default on Amplify)

Closes #388  — WebSocket binary protocol via Protocol Buffers
- Add packages/types/src/websocket.proto — canonical schema for WireMessage, WireMessageBatch, and ClientMessage
- backend/src/websocket/codec.ts — zero-dependency protobuf-compatible binary encoder (encodeWireMessage, encodeBatch) and ClientMessage decoder
- managedConnection.ts — store WireMessage objects in queue; encode as binary protobuf (WireMessageBatch) or JSON text at flush time based on useBinary flag
- server.ts — detect ?proto=1 query param; pass useBinary to ManagedConnection
- frontend/lib/websocket/codec.ts — browser-native protobuf decoder (decodeServerBinary) using TextDecoder; zero deps
- pool.ts — set binaryType='arraybuffer' when proto=1 in URL; decode binary frames with codec and re-serialize for existing ordered-delivery logic Fallback to JSON text frames for clients without ?proto=1

Closes #400  — HMAC request signing for API-to-API communication
- backend/src/middleware/internalSignature.ts — HMAC-SHA256 signing with:
  - 5-minute timestamp replay-protection window
  - Key rotation via in-memory store (loaded from INTERNAL_API_SIGNING_KEYS env)
  - signRequest() helper for outbound internal calls
  - verifyInternalSignature() Express middleware for inbound calls
  - Audit logging for all auth successes and failures

<!--
PR Template for AgenticPay monorepo work
This template guides the PR description to ensure issues are properly closed
and changes are well documented.
-->

## What this PR does
- Summary of the implemented changes related to issue(s) #240 and #242
- Any breaking changes introduced (if any)
- Any migrations or data changes (if applicable)

## Changes
- List of notable files and modules touched (monorepo wiring, Sentry integration, dashboards, etc.)
- Notes about the Turborepo configuration, shared packages, and ESLint/TS config

## Why
- Rationale for the changes and how they solve the Acceptance Criteria

## How to test
- Steps to reproduce locally, including commands to run build/test
- Any environment variables needed (e.g., SENTRY_DSN)
- How to verify the dashboards/alerts configuration (stubs or real)

## Notes
- Any caveats, risks, or follow-up tasks
- If you want to close issues automatically, include:
  - Closes #240
  - Closes #242
