### PR TITLE
feat: add PWA offline support, dashboard code splitting, EVM CI updates, and Result errors

### DIFF
--- a/.github/workflows/contracts-evm.yml
+++ b/.github/workflows/contracts-evm.yml
@@ -63,8 +63,11 @@ jobs:
       - name: Type-check scripts & tests
         run: npm run lint
 
-      - name: Run Hardhat tests
-        run: npx hardhat test
+      - name: Generate TypeChain bindings
+        run: npx hardhat typechain
+
+      - name: Run Hardhat tests with gas report
+        run: npm run test:gas
 
       - name: Run coverage
         run: npx hardhat coverage

--- a/backend/src/controllers/BaseController.ts
+++ b/backend/src/controllers/BaseController.ts
@@ -7,8 +7,39 @@
 
 import { Request, Response, NextFunction } from "express";
 import { ErrorCode } from "../middleware/responseFormatter.js";
+import { Result, ServiceError } from "../lib/result.js";
 
 export abstract class BaseController {
+
+  /**
+   * Map explicit Result errors to HTTP responses. Use this for expected
+   * business-rule outcomes; unexpected exceptions still flow through next().
+   */
+  protected sendResult<T>(
+    res: Response,
+    result: Result<T>,
+    onSuccess: (value: T) => void,
+  ): void {
+    if (result.ok) {
+      onSuccess(result.value);
+      return;
+    }
+
+    this.sendServiceError(res, result.error);
+  }
+
+  protected sendServiceError(res: Response, error: ServiceError): void {
+    res.status(error.statusCode).json({
+      error: {
+        code: error.code,
+        message: error.message,
+        details: error.details,
+      },
+      meta: {
+        timestamp: new Date().toISOString(),
+      },
+    });
+  }
   /**
    * Execute controller action with error handling
    */

--- a/backend/src/controllers/ProjectController.ts
+++ b/backend/src/controllers/ProjectController.ts
@@ -1,7 +1,8 @@
 /**
- * ProjectController.ts — Issue #366
+ * ProjectController.ts — Issue #366/#374
  *
- * HTTP layer for projects - handles request/response only
+ * HTTP layer for projects - handles request/response only and maps explicit
+ * Result service failures to stable HTTP envelopes.
  */
 
 import { Request, Response, NextFunction } from "express";
@@ -14,251 +15,153 @@ export class ProjectController extends BaseController {
     super();
   }
 
-  createProject = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  createProject = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     await this.execute(req, res, next, async (req, res) => {
       const user = this.getUser(req);
+      this.validateRequired(req.body, ["freelancerId", "amount", "description", "githubRepo"]);
 
-      this.validateRequired(req.body, [
-        "freelancerId",
-        "amount",
-        "description",
-        "githubRepo",
-      ]);
-
-      const project = await this.projectService.createProject({
+      const result = await this.projectService.createProject({
         ...req.body,
         clientId: user.id,
         tenantId: user.tenantId,
       });
 
-      res.status(201).apiSuccess(project, {
-        message: "Project created successfully",
+      this.sendResult(res, result, (project) => {
+        res.status(201).apiSuccess(project, { message: "Project created successfully" });
       });
     });
   };
 
-  getProject = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  getProject = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     await this.execute(req, res, next, async (req, res) => {
       const user = this.getUser(req);
-      const { id } = req.params;
-
-      const project = await this.projectService.getProject(id, user.tenantId);
-
-      res.apiSuccess(project);
+      const result = await this.projectService.getProject(req.params.id, user.tenantId);
+      this.sendResult(res, result, (project) => res.apiSuccess(project));
     });
   };
 
-  listProjects = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  listProjects = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     await this.execute(req, res, next, async (req, res) => {
       const user = this.getUser(req);
       const pagination = this.getPaginationParams(req);
+      const result = await this.projectService.listProjects(user.tenantId, pagination);
 
-      const result = await this.projectService.listProjects(
-        user.tenantId,
-        pagination,
-      );
-
-      const paginationMeta = buildPaginationMeta(
-        result.items,
-        pagination.limit,
-        result.hasMore,
-      );
-
-      res.apiPaginated(result.items, paginationMeta);
+      this.sendResult(res, result, (projects) => {
+        res.apiPaginated(
+          projects.items,
+          buildPaginationMeta(projects.items, pagination.limit, projects.hasMore),
+        );
+      });
     });
   };
 
-  listClientProjects = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  listClientProjects = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     await this.execute(req, res, next, async (req, res) => {
       const user = this.getUser(req);
-      const { clientId } = req.params;
       const pagination = this.getPaginationParams(req);
-
       const result = await this.projectService.listClientProjects(
-        clientId,
+        req.params.clientId,
         user.tenantId,
         pagination,
       );
 
-      const paginationMeta = buildPaginationMeta(
-        result.items,
-        pagination.limit,
-        result.hasMore,
-      );
-
-      res.apiPaginated(result.items, paginationMeta);
-    });
-  };
-
-  listFreelancerProjects = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
-    await this.execute(req, res, next, async (req, res) => {
-      const user = this.getUser(req);
-      const { freelancerId } = req.params;
-      const pagination = this.getPaginationParams(req);
-
-      const result = await this.projectService.listFreelancerProjects(
-        freelancerId,
-        user.tenantId,
-        pagination,
-      );
-
-      const paginationMeta = buildPaginationMeta(
-        result.items,
-        pagination.limit,
-        result.hasMore,
-      );
-
-      res.apiPaginated(result.items, paginationMeta);
-    });
-  };
-
-  updateProject = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
-    await this.execute(req, res, next, async (req, res) => {
-      const user = this.getUser(req);
-      const { id } = req.params;
-
-      const project = await this.projectService.updateProject(
-        id,
-        req.body,
-        user.tenantId,
-      );
-
-      res.apiSuccess(project, {
-        message: "Project updated successfully",
+      this.sendResult(res, result, (projects) => {
+        res.apiPaginated(
+          projects.items,
+          buildPaginationMeta(projects.items, pagination.limit, projects.hasMore),
+        );
       });
     });
   };
 
-  fundProject = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  listFreelancerProjects = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     await this.execute(req, res, next, async (req, res) => {
       const user = this.getUser(req);
-      const { id } = req.params;
+      const pagination = this.getPaginationParams(req);
+      const result = await this.projectService.listFreelancerProjects(
+        req.params.freelancerId,
+        user.tenantId,
+        pagination,
+      );
 
+      this.sendResult(res, result, (projects) => {
+        res.apiPaginated(
+          projects.items,
+          buildPaginationMeta(projects.items, pagination.limit, projects.hasMore),
+        );
+      });
+    });
+  };
+
+  updateProject = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    await this.execute(req, res, next, async (req, res) => {
+      const user = this.getUser(req);
+      const result = await this.projectService.updateProject(req.params.id, req.body, user.tenantId);
+      this.sendResult(res, result, (project) => {
+        res.apiSuccess(project, { message: "Project updated successfully" });
+      });
+    });
+  };
+
+  fundProject = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    await this.execute(req, res, next, async (req, res) => {
+      const user = this.getUser(req);
       this.validateRequired(req.body, ["amount"]);
 
-      const project = await this.projectService.fundProject(
-        id,
-        {
-          amount: req.body.amount,
-          clientId: user.id,
-        },
+      const result = await this.projectService.fundProject(
+        req.params.id,
+        { amount: req.body.amount, clientId: user.id },
         user.tenantId,
       );
 
-      res.apiSuccess(project, {
-        message: "Project funded successfully",
+      this.sendResult(res, result, (project) => {
+        res.apiSuccess(project, { message: "Project funded successfully" });
       });
     });
   };
 
-  submitWork = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  submitWork = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     await this.execute(req, res, next, async (req, res) => {
       const user = this.getUser(req);
-      const { id } = req.params;
-
       this.validateRequired(req.body, ["githubRepo"]);
 
-      const project = await this.projectService.submitWork(
-        id,
-        {
-          githubRepo: req.body.githubRepo,
-          freelancerId: user.id,
-        },
+      const result = await this.projectService.submitWork(
+        req.params.id,
+        { githubRepo: req.body.githubRepo, freelancerId: user.id },
         user.tenantId,
       );
 
-      res.apiSuccess(project, {
-        message: "Work submitted successfully",
+      this.sendResult(res, result, (project) => {
+        res.apiSuccess(project, { message: "Work submitted successfully" });
       });
     });
   };
 
-  approveWork = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  approveWork = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     await this.execute(req, res, next, async (req, res) => {
       const user = this.getUser(req);
-      const { id } = req.params;
-
-      const project = await this.projectService.approveWork(
-        id,
-        user.id,
-        user.tenantId,
-      );
-
-      res.apiSuccess(project, {
-        message: "Work approved and payment released",
+      const result = await this.projectService.approveWork(req.params.id, user.id, user.tenantId);
+      this.sendResult(res, result, (project) => {
+        res.apiSuccess(project, { message: "Work approved and payment released" });
       });
     });
   };
 
-  raiseDispute = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  raiseDispute = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     await this.execute(req, res, next, async (req, res) => {
       const user = this.getUser(req);
-      const { id } = req.params;
-
-      const project = await this.projectService.raiseDispute(
-        id,
-        user.id,
-        user.tenantId,
-      );
-
-      res.apiSuccess(project, {
-        message: "Dispute raised successfully",
+      const result = await this.projectService.raiseDispute(req.params.id, user.id, user.tenantId);
+      this.sendResult(res, result, (project) => {
+        res.apiSuccess(project, { message: "Dispute raised successfully" });
       });
     });
   };
 
-  deleteProject = async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
+  deleteProject = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     await this.execute(req, res, next, async (req, res) => {
       const user = this.getUser(req);
-      const { id } = req.params;
-
-      await this.projectService.deleteProject(id, user.tenantId);
-
-      res.status(204).send();
+      const result = await this.projectService.deleteProject(req.params.id, user.tenantId);
+      this.sendResult(res, result, () => res.status(204).send());
     });
   };
 }

--- a/backend/src/controllers/__tests__/ProjectController.test.ts
+++ b/backend/src/controllers/__tests__/ProjectController.test.ts
@@ -6,7 +6,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Request, Response, NextFunction } from "express";
 import { ProjectController } from "../ProjectController.js";
 import { ProjectService } from "../../services/ProjectService.js";
-import { ProjectRepository } from "../../repositories/ProjectRepository.js";
+import { Project, ProjectRepository } from "../../repositories/ProjectRepository.js";
+import { Result } from "../../lib/result.js";
 
 describe("ProjectController", () => {
   let controller: ProjectController;
@@ -35,6 +36,7 @@ describe("ProjectController", () => {
     res = {
       status: vi.fn().mockReturnThis(),
       send: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
       apiSuccess: vi.fn().mockReturnThis(),
       apiPaginated: vi.fn().mockReturnThis(),
     };
@@ -70,14 +72,14 @@ describe("ProjectController", () => {
 
   describe("getProject", () => {
     it("should get a project by ID", async () => {
-      const project = await service.createProject({
+      const project = unwrapProject(await service.createProject({
         clientId: "user1",
         freelancerId: "freelancer1",
         amount: 1000,
         description: "Test",
         githubRepo: "https://github.com/test/repo",
         tenantId: "tenant1",
-      });
+      }));
 
       req.params = { id: project.id };
 
@@ -91,7 +93,8 @@ describe("ProjectController", () => {
 
       await controller.getProject(req as Request, res as Response, next);
 
-      expect(next).toHaveBeenCalledWith(expect.any(Error));
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.objectContaining({ code: "NOT_FOUND" }) }));
     });
   });
 
@@ -125,14 +128,14 @@ describe("ProjectController", () => {
 
   describe("updateProject", () => {
     it("should update a project", async () => {
-      const project = await service.createProject({
+      const project = unwrapProject(await service.createProject({
         clientId: "user1",
         freelancerId: "freelancer1",
         amount: 1000,
         description: "Test",
         githubRepo: "https://github.com/test/repo",
         tenantId: "tenant1",
-      });
+      }));
 
       req.params = { id: project.id };
       req.body = { description: "Updated description" };
@@ -145,14 +148,14 @@ describe("ProjectController", () => {
 
   describe("fundProject", () => {
     it("should fund a project", async () => {
-      const project = await service.createProject({
+      const project = unwrapProject(await service.createProject({
         clientId: "user1",
         freelancerId: "freelancer1",
         amount: 1000,
         description: "Test",
         githubRepo: "https://github.com/test/repo",
         tenantId: "tenant1",
-      });
+      }));
 
       req.params = { id: project.id };
       req.body = { amount: 1000 };
@@ -163,14 +166,14 @@ describe("ProjectController", () => {
     });
 
     it("should validate amount", async () => {
-      const project = await service.createProject({
+      const project = unwrapProject(await service.createProject({
         clientId: "user1",
         freelancerId: "freelancer1",
         amount: 1000,
         description: "Test",
         githubRepo: "https://github.com/test/repo",
         tenantId: "tenant1",
-      });
+      }));
 
       req.params = { id: project.id };
       req.body = {};
@@ -183,14 +186,14 @@ describe("ProjectController", () => {
 
   describe("submitWork", () => {
     it("should submit work", async () => {
-      const project = await service.createProject({
+      const project = unwrapProject(await service.createProject({
         clientId: "user1",
         freelancerId: "freelancer1",
         amount: 1000,
         description: "Test",
         githubRepo: "https://github.com/test/repo",
         tenantId: "tenant1",
-      });
+      }));
 
       await service.fundProject(
         project.id,
@@ -214,14 +217,14 @@ describe("ProjectController", () => {
 
   describe("approveWork", () => {
     it("should approve work and release payment", async () => {
-      const project = await service.createProject({
+      const project = unwrapProject(await service.createProject({
         clientId: "user1",
         freelancerId: "freelancer1",
         amount: 1000,
         description: "Test",
         githubRepo: "https://github.com/test/repo",
         tenantId: "tenant1",
-      });
+      }));
 
       await service.fundProject(
         project.id,
@@ -248,14 +251,14 @@ describe("ProjectController", () => {
 
   describe("raiseDispute", () => {
     it("should raise a dispute", async () => {
-      const project = await service.createProject({
+      const project = unwrapProject(await service.createProject({
         clientId: "user1",
         freelancerId: "freelancer1",
         amount: 1000,
         description: "Test",
         githubRepo: "https://github.com/test/repo",
         tenantId: "tenant1",
-      });
+      }));
 
       await service.fundProject(
         project.id,
@@ -273,14 +276,14 @@ describe("ProjectController", () => {
 
   describe("deleteProject", () => {
     it("should delete an unfunded project", async () => {
-      const project = await service.createProject({
+      const project = unwrapProject(await service.createProject({
         clientId: "user1",
         freelancerId: "freelancer1",
         amount: 1000,
         description: "Test",
         githubRepo: "https://github.com/test/repo",
         tenantId: "tenant1",
-      });
+      }));
 
       req.params = { id: project.id };
 
@@ -290,14 +293,14 @@ describe("ProjectController", () => {
     });
 
     it("should not delete funded project", async () => {
-      const project = await service.createProject({
+      const project = unwrapProject(await service.createProject({
         clientId: "user1",
         freelancerId: "freelancer1",
         amount: 1000,
         description: "Test",
         githubRepo: "https://github.com/test/repo",
         tenantId: "tenant1",
-      });
+      }));
 
       await service.fundProject(
         project.id,
@@ -309,7 +312,15 @@ describe("ProjectController", () => {
 
       await controller.deleteProject(req as Request, res as Response, next);
 
-      expect(next).toHaveBeenCalledWith(expect.any(Error));
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.objectContaining({ code: "VALIDATION_ERROR" }) }));
     });
   });
 });
+
+function unwrapProject(result: Result<Project>): Project {
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+  return result.value;
+}

--- a/backend/src/lib/result.ts
+++ b/backend/src/lib/result.ts
@@ -1,0 +1,55 @@
+export type Result<T, E = ServiceError> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+export interface ServiceError {
+  code: string;
+  message: string;
+  statusCode: number;
+  details?: Record<string, unknown>;
+  cause?: unknown;
+}
+
+export function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value };
+}
+
+export function err<E extends ServiceError>(error: E): Result<never, E> {
+  return { ok: false, error };
+}
+
+export function isOk<T, E>(result: Result<T, E>): result is { ok: true; value: T } {
+  return result.ok;
+}
+
+export function isErr<T, E>(result: Result<T, E>): result is { ok: false; error: E } {
+  return !result.ok;
+}
+
+export async function fromThrowable<T>(operation: () => Promise<T>): Promise<Result<T>> {
+  try {
+    return ok(await operation());
+  } catch (error) {
+    return err(toServiceError(error));
+  }
+}
+
+export function toServiceError(error: unknown): ServiceError {
+  if (typeof error === 'object' && error !== null && 'statusCode' in error && 'code' in error && 'message' in error) {
+    const typed = error as { statusCode: number; code: string; message: string; details?: Record<string, unknown> };
+    return {
+      code: typed.code,
+      message: typed.message,
+      statusCode: typed.statusCode,
+      details: typed.details,
+      cause: error,
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: error instanceof Error ? error.message : 'Unexpected service error',
+    statusCode: 500,
+    cause: error,
+  };
+}

--- a/backend/src/services/BaseService.ts
+++ b/backend/src/services/BaseService.ts
@@ -5,7 +5,43 @@
  * Services coordinate between repositories and implement business rules
  */
 
+import { err, ok, Result, ServiceError } from '../lib/result.js';
+
 export abstract class BaseService {
+
+  protected ok<T>(value: T): Result<T> {
+    return ok(value);
+  }
+
+  protected fail(message: string, statusCode: number, code: string, details?: Record<string, unknown>): Result<never> {
+    return err({ code, message, statusCode, details });
+  }
+
+  protected validationFailure(message: string, details?: Record<string, unknown>): Result<never> {
+    return this.fail(message, 400, "VALIDATION_ERROR", details);
+  }
+
+  protected notFoundFailure(resource: string, id: string): Result<never> {
+    return this.fail(`${resource} not found: ${id}`, 404, "NOT_FOUND");
+  }
+
+  protected forbiddenFailure(message: string): Result<never> {
+    return this.fail(message, 403, "FORBIDDEN");
+  }
+
+  protected conflictFailure(message: string): Result<never> {
+    return this.fail(message, 409, "CONFLICT");
+  }
+
+  protected unexpectedFailure(error: unknown): Result<never> {
+    const serviceError: ServiceError = {
+      code: "INTERNAL_ERROR",
+      message: error instanceof Error ? error.message : "Unexpected service error",
+      statusCode: 500,
+      cause: error,
+    };
+    return err(serviceError);
+  }
   /**
    * Validate business rules
    */

--- a/backend/src/services/ProjectService.ts
+++ b/backend/src/services/ProjectService.ts
@@ -1,7 +1,9 @@
 /**
- * ProjectService.ts — Issue #366
+ * ProjectService.ts — Issue #366/#374
  *
- * Business logic layer for projects
+ * Business logic layer for projects. Expected business-rule failures are
+ * returned as Result errors; exceptions are reserved for unexpected runtime
+ * failures from infrastructure dependencies.
  */
 
 import { BaseService } from "./BaseService.js";
@@ -9,7 +11,8 @@ import {
   ProjectRepository,
   Project,
 } from "../repositories/ProjectRepository.js";
-import { PaginationOptions } from "../repositories/BaseRepository.js";
+import { PaginationOptions, PaginatedResult } from "../repositories/BaseRepository.js";
+import { Result } from "../lib/result.js";
 
 export interface CreateProjectDTO {
   clientId: string;
@@ -44,221 +47,193 @@ export class ProjectService extends BaseService {
     super();
   }
 
-  async createProject(data: CreateProjectDTO): Promise<Project> {
-    // Validate business rules
-    this.validate(data.amount > 0, "Project amount must be positive");
-    this.validate(
-      data.clientId !== data.freelancerId,
-      "Client and freelancer must be different",
-    );
-
-    if (data.deadline) {
-      const deadlineDate = new Date(data.deadline);
-      this.validate(
-        deadlineDate > new Date(),
-        "Deadline must be in the future",
-      );
+  async createProject(data: CreateProjectDTO): Promise<Result<Project>> {
+    if (data.amount <= 0) {
+      return this.validationFailure("Project amount must be positive");
+    }
+    if (data.clientId === data.freelancerId) {
+      return this.validationFailure("Client and freelancer must be different");
+    }
+    if (data.deadline && new Date(data.deadline) <= new Date()) {
+      return this.validationFailure("Deadline must be in the future");
     }
 
-    return await this.projectRepository.create(data);
+    return this.ok(await this.projectRepository.create(data));
   }
 
-  async getProject(id: string, tenantId: string): Promise<Project> {
+  async getProject(id: string, tenantId: string): Promise<Result<Project>> {
     const project = await this.projectRepository.findById(id);
 
     if (!project) {
-      this.notFound("Project", id);
+      return this.notFoundFailure("Project", id);
     }
 
-    // Tenant isolation
     if (project.tenantId !== tenantId) {
-      this.forbidden("Access denied to this project");
+      return this.forbiddenFailure("Access denied to this project");
     }
 
-    return project;
+    return this.ok(project);
   }
 
-  async listProjects(tenantId: string, options: PaginationOptions) {
-    return await this.projectRepository.findByTenant(tenantId, options);
+  async listProjects(
+    tenantId: string,
+    options: PaginationOptions,
+  ): Promise<Result<PaginatedResult<Project>>> {
+    return this.ok(await this.projectRepository.findByTenant(tenantId, options));
   }
 
   async listClientProjects(
     clientId: string,
-    tenantId: string,
+    _tenantId: string,
     options: PaginationOptions,
-  ) {
-    // Verify client belongs to tenant (in real app, check user-tenant relationship)
-    return await this.projectRepository.findByClient(clientId, options);
+  ): Promise<Result<PaginatedResult<Project>>> {
+    // Tenant membership validation belongs in the user/tenant repository once wired.
+    return this.ok(await this.projectRepository.findByClient(clientId, options));
   }
 
   async listFreelancerProjects(
     freelancerId: string,
-    tenantId: string,
+    _tenantId: string,
     options: PaginationOptions,
-  ) {
-    // Verify freelancer belongs to tenant
-    return await this.projectRepository.findByFreelancer(freelancerId, options);
+  ): Promise<Result<PaginatedResult<Project>>> {
+    return this.ok(await this.projectRepository.findByFreelancer(freelancerId, options));
   }
 
   async updateProject(
     id: string,
     data: UpdateProjectDTO,
     tenantId: string,
-  ): Promise<Project> {
-    const project = await this.getProject(id, tenantId);
+  ): Promise<Result<Project>> {
+    const projectResult = await this.getProject(id, tenantId);
+    if (!projectResult.ok) return projectResult;
 
-    // Validate state transitions
     if (data.status) {
-      this.validateStatusTransition(project.status, data.status);
+      const transition = this.validateStatusTransition(projectResult.value.status, data.status);
+      if (!transition.ok) return transition;
     }
 
-    if (data.amount !== undefined) {
-      this.validate(data.amount > 0, "Project amount must be positive");
+    if (data.amount !== undefined && data.amount <= 0) {
+      return this.validationFailure("Project amount must be positive");
     }
 
     const updated = await this.projectRepository.update(id, data);
-    if (!updated) {
-      this.notFound("Project", id);
-    }
-
-    return updated;
+    return updated ? this.ok(updated) : this.notFoundFailure("Project", id);
   }
 
   async fundProject(
     id: string,
     data: FundProjectDTO,
     tenantId: string,
-  ): Promise<Project> {
-    const project = await this.getProject(id, tenantId);
+  ): Promise<Result<Project>> {
+    const projectResult = await this.getProject(id, tenantId);
+    if (!projectResult.ok) return projectResult;
+    const project = projectResult.value;
 
-    // Validate business rules
-    this.validate(
-      project.clientId === data.clientId,
-      "Only project client can fund",
-    );
-    this.validate(
-      project.status === "created",
-      "Project must be in created status",
-    );
-    this.validate(data.amount > 0, "Funding amount must be positive");
+    if (project.clientId !== data.clientId) {
+      return this.validationFailure("Only project client can fund");
+    }
+    if (project.status !== "created") {
+      return this.validationFailure("Project must be in created status");
+    }
+    if (data.amount <= 0) {
+      return this.validationFailure("Funding amount must be positive");
+    }
 
     const newDeposited = project.deposited + data.amount;
     const newStatus = newDeposited >= project.amount ? "funded" : "created";
-
     const updated = await this.projectRepository.update(id, {
       deposited: newDeposited,
       status: newStatus,
     });
 
-    if (!updated) {
-      this.notFound("Project", id);
-    }
-
-    return updated;
+    return updated ? this.ok(updated) : this.notFoundFailure("Project", id);
   }
 
   async submitWork(
     id: string,
     data: SubmitWorkDTO,
     tenantId: string,
-  ): Promise<Project> {
-    const project = await this.getProject(id, tenantId);
+  ): Promise<Result<Project>> {
+    const projectResult = await this.getProject(id, tenantId);
+    if (!projectResult.ok) return projectResult;
+    const project = projectResult.value;
 
-    // Validate business rules
-    this.validate(
-      project.freelancerId === data.freelancerId,
-      "Only assigned freelancer can submit work",
-    );
-    this.validate(
-      project.status === "funded" || project.status === "in_progress",
-      "Project must be funded or in progress",
-    );
+    if (project.freelancerId !== data.freelancerId) {
+      return this.validationFailure("Only assigned freelancer can submit work");
+    }
+    if (project.status !== "funded" && project.status !== "in_progress") {
+      return this.validationFailure("Project must be funded or in progress");
+    }
 
     const updated = await this.projectRepository.update(id, {
       githubRepo: data.githubRepo,
       status: "work_submitted",
     });
 
-    if (!updated) {
-      this.notFound("Project", id);
-    }
-
-    return updated;
+    return updated ? this.ok(updated) : this.notFoundFailure("Project", id);
   }
 
   async approveWork(
     id: string,
     clientId: string,
     tenantId: string,
-  ): Promise<Project> {
-    const project = await this.getProject(id, tenantId);
+  ): Promise<Result<Project>> {
+    const projectResult = await this.getProject(id, tenantId);
+    if (!projectResult.ok) return projectResult;
+    const project = projectResult.value;
 
-    // Validate business rules
-    this.validate(
-      project.clientId === clientId,
-      "Only project client can approve",
-    );
-    this.validate(
-      project.status === "work_submitted" || project.status === "verified",
-      "Work must be submitted or verified",
-    );
-
-    // In real implementation, transfer funds here
-    const updated = await this.projectRepository.update(id, {
-      status: "completed",
-      deposited: 0, // Funds released
-    });
-
-    if (!updated) {
-      this.notFound("Project", id);
+    if (project.clientId !== clientId) {
+      return this.validationFailure("Only project client can approve");
+    }
+    if (project.status !== "work_submitted" && project.status !== "verified") {
+      return this.validationFailure("Work must be submitted or verified");
     }
 
-    return updated;
+    const updated = await this.projectRepository.update(id, {
+      status: "completed",
+      deposited: 0,
+    });
+
+    return updated ? this.ok(updated) : this.notFoundFailure("Project", id);
   }
 
   async raiseDispute(
     id: string,
     userId: string,
     tenantId: string,
-  ): Promise<Project> {
-    const project = await this.getProject(id, tenantId);
+  ): Promise<Result<Project>> {
+    const projectResult = await this.getProject(id, tenantId);
+    if (!projectResult.ok) return projectResult;
+    const project = projectResult.value;
 
-    // Validate business rules
-    this.validate(
-      project.clientId === userId || project.freelancerId === userId,
-      "Only client or freelancer can raise dispute",
-    );
+    if (project.clientId !== userId && project.freelancerId !== userId) {
+      return this.validationFailure("Only client or freelancer can raise dispute");
+    }
 
     const updated = await this.projectRepository.update(id, {
       status: "disputed",
     });
 
-    if (!updated) {
-      this.notFound("Project", id);
-    }
-
-    return updated;
+    return updated ? this.ok(updated) : this.notFoundFailure("Project", id);
   }
 
-  async deleteProject(id: string, tenantId: string): Promise<void> {
-    const project = await this.getProject(id, tenantId);
+  async deleteProject(id: string, tenantId: string): Promise<Result<void>> {
+    const projectResult = await this.getProject(id, tenantId);
+    if (!projectResult.ok) return projectResult;
+    const project = projectResult.value;
 
-    // Validate business rules
-    this.validate(
-      project.status === "created" && project.deposited === 0,
-      "Can only delete unfunded projects",
-    );
+    if (project.status !== "created" || project.deposited !== 0) {
+      return this.validationFailure("Can only delete unfunded projects");
+    }
 
     const deleted = await this.projectRepository.delete(id);
-    if (!deleted) {
-      this.notFound("Project", id);
-    }
+    return deleted ? this.ok(undefined) : this.notFoundFailure("Project", id);
   }
 
   private validateStatusTransition(
     from: Project["status"],
     to: Project["status"],
-  ): void {
+  ): Result<void> {
     const validTransitions: Record<Project["status"], Project["status"][]> = {
       created: ["funded", "cancelled"],
       funded: ["in_progress", "cancelled"],
@@ -271,9 +246,8 @@ export class ProjectService extends BaseService {
     };
 
     const allowed = validTransitions[from] || [];
-    this.validate(
-      allowed.includes(to),
-      `Invalid status transition from ${from} to ${to}`,
-    );
+    return allowed.includes(to)
+      ? this.ok(undefined)
+      : this.validationFailure(`Invalid status transition from ${from} to ${to}`);
   }
 }

--- a/contracts/evm/hardhat.config.ts
+++ b/contracts/evm/hardhat.config.ts
@@ -95,6 +95,18 @@ const config: HardhatUserConfig = {
     },
   },
 
+  typechain: {
+    outDir: 'typechain-types',
+    target: 'ethers-v6',
+  },
+
+  gasReporter: {
+    enabled: process.env.REPORT_GAS === 'true',
+    currency: 'USD',
+    coinmarketcap: process.env.COINMARKETCAP_API_KEY,
+    excludeContracts: ['contracts/test/'],
+  },
+
   // Etherscan v2 exposes a unified endpoint, so a single ETHERSCAN_API_KEY
   // can verify across supported chains. Chain-specific keys override it.
   etherscan: {

--- a/contracts/evm/package.json
+++ b/contracts/evm/package.json
@@ -16,7 +16,9 @@
     "verify:deployment": "hardhat run scripts/verify.ts",
     "propose:upgrade": "hardhat run scripts/propose-safe-upgrade.ts",
     "list": "hardhat run scripts/list-deployments.ts",
-    "rollback": "hardhat run scripts/rollback.ts"
+    "rollback": "hardhat run scripts/rollback.ts",
+    "typechain": "hardhat typechain",
+    "ci": "npm run compile && npm run typechain && npm run lint && npm run test:gas"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",

--- a/docs/frontend/bundle-splitting.md
+++ b/docs/frontend/bundle-splitting.md
@@ -1,0 +1,18 @@
+# Frontend route chunking and bundle analysis
+
+Issue #369 moved heavy dashboard visualization code behind a Next.js dynamic import so the dashboard route can render its stat cards before the Recharts chunk arrives. The sidebar now prefetches likely-next dashboard routes on hover/focus to keep navigation responsive without eagerly loading every route during the initial render.
+
+## How to compare bundle size
+
+Run these commands from the repository root:
+
+```bash
+cd frontend
+ANALYZE=true npm run build
+```
+
+The bundle analyzer opens the client/server reports and can be used to compare the dashboard route before and after this change. The expected win is that `recharts` is no longer part of the initial dashboard page chunk and is instead loaded as an async chunk with a chart skeleton fallback.
+
+## Slow-network behavior
+
+Dashboard chart chunks render skeleton cards while loading. If a chunk load fails, the dashboard segment error boundary displays a retry action, allowing users on slow or stale deployments to recover after the service worker activates the latest app cache.

--- a/docs/result-pattern-migration.md
+++ b/docs/result-pattern-migration.md
@@ -1,0 +1,46 @@
+# Result pattern migration guide
+
+Issue #374 introduces explicit `Result<T, E>` handling for expected service failures.
+
+## Service contract
+
+Services should return `Promise<Result<T>>` for expected business outcomes:
+
+```ts
+const result = await projectService.getProject(id, tenantId);
+if (!result.ok) return result;
+return ok(result.value);
+```
+
+Use Result errors for validation, not-found, forbidden, and conflict cases. Reserve thrown exceptions for unexpected runtime failures such as programming errors, dependency crashes, or unavailable infrastructure.
+
+## Controller contract
+
+Controllers should map Result values to HTTP responses at the edge:
+
+```ts
+const result = await service.updateProject(id, body, tenantId);
+this.sendResult(res, result, (project) => {
+  res.apiSuccess(project);
+});
+```
+
+This keeps business logic deterministic and avoids relying on exception control flow for normal client errors.
+
+## Error hierarchy
+
+Shared primitives live in `packages/types/src/exports.ts` for SDK/API consumers and `backend/src/lib/result.ts` for backend runtime code. Use the following status conventions:
+
+- `VALIDATION_ERROR`: 400
+- `NOT_FOUND`: 404
+- `FORBIDDEN`: 403
+- `CONFLICT`: 409
+- `INTERNAL_ERROR`: 500 for unexpected failures only
+
+## Incremental migration checklist
+
+1. Change one service method at a time to return `Promise<Result<T>>`.
+2. Replace expected `throw` calls with typed `validationFailure`, `notFoundFailure`, `forbiddenFailure`, or `conflictFailure` helpers.
+3. Update controller call sites to use `sendResult`.
+4. Update tests to assert Result envelopes for service tests and HTTP envelopes for controller tests.
+5. Keep third-party library calls wrapped at service boundaries so library exceptions become `INTERNAL_ERROR` only when they are genuinely unexpected.

--- a/frontend/app/dashboard/DashboardCharts.tsx
+++ b/frontend/app/dashboard/DashboardCharts.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { TrendingUp } from 'lucide-react';
+import { motion } from 'framer-motion';
+import {
+  LineChart,
+  Line,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+
+interface DashboardChartsProps {
+  trendData: Array<{ month: string; revenue: number; earnings: number }>;
+  distributionData: Array<{ name: string; value: number; color: string }>;
+}
+
+export default function DashboardCharts({ trendData, distributionData }: DashboardChartsProps) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.6 }}>
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              Revenue Trends
+              <TrendingUp className="h-5 w-5 text-green-600" />
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={320}>
+              <LineChart data={trendData}>
+                <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
+                <XAxis dataKey="month" />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="revenue" stroke="#3b82f6" strokeWidth={3} name="Revenue" />
+                <Line type="monotone" dataKey="earnings" stroke="#10b981" strokeWidth={3} name="Earnings" />
+              </LineChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </motion.div>
+
+      <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.7 }}>
+        <Card>
+          <CardHeader>
+            <CardTitle>Portfolio Distribution</CardTitle>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <ResponsiveContainer width="100%" height={320}>
+              <PieChart>
+                <Pie
+                  data={distributionData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={70}
+                  outerRadius={110}
+                  dataKey="value"
+                  label={({ name, percent }) => `${name} ${((percent || 0) * 100).toFixed(0)}%`}
+                >
+                  {distributionData.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip />
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </motion.div>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,33 +1,33 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useDashboardData } from '@/lib/hooks/useDashboardData';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { DollarSign, Clock, Folder, CheckCircle2, TrendingUp } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { DashboardStatsSkeleton } from '@/components/ui/loading-skeletons';
-import {
-  LineChart,
-  Line,
-  PieChart,
-  Pie,
-  Cell,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
-} from 'recharts';
+
+
+const DashboardCharts = dynamic(() => import('./DashboardCharts'), {
+  ssr: false,
+  loading: () => (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      {[0, 1].map((item) => (
+        <Card key={item}>
+          <CardHeader>
+            <div className="h-6 w-40 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+          </CardHeader>
+          <CardContent>
+            <div className="h-80 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  ),
+});
 
 export default function DashboardPage() {
   const { stats, recentActivity, loading } = useDashboardData();
-
-  const metrics = [
-    { title: 'Total Earnings', value: stats.totalEarnings, suffix: ' USD', icon: DollarSign, accent: 'text-emerald-600' },
-    { title: 'Pending Payments', value: stats.pendingPayments, suffix: ' USD', icon: Clock, accent: 'text-amber-600' },
-    { title: 'Active Projects', value: String(stats.activeProjects), suffix: '', icon: Folder, accent: 'text-blue-600' },
-    { title: 'Completed Projects', value: String(stats.completedProjects), suffix: '', icon: CheckCircle2, accent: 'text-violet-600' },
-  ];
 
   if (loading) {
     return (
@@ -116,83 +116,8 @@ export default function DashboardPage() {
         ))}
       </div>
 
-      {/* Charts Section */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* 1. Line Chart - Trends */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.6 }}
-        >
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                Revenue Trends
-                <TrendingUp className="h-5 w-5 text-green-600" />
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ResponsiveContainer width="100%" height={320}>
-                <LineChart data={trendData}>
-                  <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
-                  <XAxis dataKey="month" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Line
-                    type="monotone"
-                    dataKey="revenue"
-                    stroke="#3b82f6"
-                    strokeWidth={3}
-                    name="Revenue"
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="earnings"
-                    stroke="#10b981"
-                    strokeWidth={3}
-                    name="Earnings"
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            </CardContent>
-          </Card>
-        </motion.div>
-
-        {/* 2. Pie Chart - Distribution */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.7 }}
-        >
-          <Card>
-            <CardHeader>
-              <CardTitle>Portfolio Distribution</CardTitle>
-            </CardHeader>
-            <CardContent className="flex justify-center">
-              <ResponsiveContainer width="100%" height={320}>
-                <PieChart>
-                  <Pie
-                    data={distributionData}
-                    cx="50%"
-                    cy="50%"
-                    innerRadius={70}
-                    outerRadius={110}
-                    dataKey="value"
-                    label={({ name, percent }) => `${name} ${((percent || 0) * 100).toFixed(0)}%`}
-                  >
-                    {distributionData.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={entry.color} />
-                    ))}
-                  </Pie>
-                  <Tooltip />
-                  <Legend />
-                </PieChart>
-              </ResponsiveContainer>
-            </CardContent>
-          </Card>
-        </motion.div>
-      </div>
+      {/* Charts Section - dynamically imported to keep recharts out of the initial route chunk. */}
+      <DashboardCharts trendData={trendData} distributionData={distributionData} />
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <Card className="lg:col-span-2">

--- a/frontend/app/dashboard/projects/page.tsx
+++ b/frontend/app/dashboard/projects/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Plus, ExternalLink, Clock, Folder } from 'lucide-react';
 import { Plus, ExternalLink, Clock, Folder, Loader2, Filter } from 'lucide-react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { Providers } from "@/components/providers";
 import PWAWrapper from "@/components/PWAWrapper";
 import { LanguageProvider } from "@/components/providers/LanguageProvider";
+import { OfflineProvider } from "@/components/offline/OfflineProvider";
 
 // Using system fonts defined in globals.css to avoid network dependencies during build
 
@@ -37,7 +38,7 @@ export default function RootLayout({
       >
         <Providers>
           <LanguageProvider>
-            {children}
+            <OfflineProvider>{children}</OfflineProvider>
           </LanguageProvider>
           <PWAWrapper />
         </Providers>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { LayoutDashboard, Folder, FileText, Wallet, Scale, Menu, X, QrCode } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
@@ -18,6 +18,7 @@ const navigation = [
 
 export function Sidebar() {
   const pathname = usePathname();
+  const router = useRouter();
   const [isMobileOpen, setIsMobileOpen] = useState(false);
 
   return (
@@ -72,6 +73,8 @@ export function Sidebar() {
                 <Link
                   key={item.name}
                   href={item.href}
+                  onMouseEnter={() => router.prefetch(item.href)}
+                  onFocus={() => router.prefetch(item.href)}
                   onClick={() => setIsMobileOpen(false)}
                   className={cn(
                     'flex items-center gap-3 px-4 py-3 rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-blue-500',

--- a/frontend/components/offline/OfflineProvider.tsx
+++ b/frontend/components/offline/OfflineProvider.tsx
@@ -28,9 +28,11 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
+    let serviceWorkerQueueLength = 0;
+
     const syncQueueState = () => {
       setOnline(window.navigator.onLine);
-      setQueueLength(getQueuedActionCount());
+      setQueueLength(getQueuedActionCount() + serviceWorkerQueueLength);
     };
 
     const flushQueuedActions = async () => {
@@ -68,11 +70,28 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
       toast.warning('You are offline. New API actions will be queued until the connection returns.');
     };
 
+    const handleServiceWorkerMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'PAYMENT_QUEUE_CHANGED') {
+        serviceWorkerQueueLength = Number(event.data.remaining) || 0;
+        syncQueueState();
+      }
+
+      if (event.data?.type === 'PAYMENT_QUEUE_SYNCED') {
+        serviceWorkerQueueLength = Number(event.data.remaining) || 0;
+        syncQueueState();
+
+        if (event.data.synced > 0) {
+          toast.success(`Synced ${event.data.synced} offline payment${event.data.synced === 1 ? '' : 's'}.`);
+        }
+      }
+    };
+
     syncQueueState();
 
     const unsubscribe = subscribeToOfflineQueue(syncQueueState);
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
+    window.navigator.serviceWorker?.addEventListener('message', handleServiceWorkerMessage);
 
     if (window.navigator.onLine) {
       void flushQueuedActions();
@@ -82,6 +101,7 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
       unsubscribe();
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
+      window.navigator.serviceWorker?.removeEventListener('message', handleServiceWorkerMessage);
     };
   }, [setOnline, setQueueLength, setSyncing]);
 

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,25 +1,333 @@
-// public/sw.js
+// AgenticPay service worker: offline shell, API fallback cache, and payment replay queue.
 
-const CACHE_NAME = "agenticpay-cache-v1";
-const urlsToCache = ["/", "/icons/image-192.png", "/icons/image-512.png"];
+const APP_VERSION = '2026-06-01.1';
+const CACHE_PREFIX = 'agenticpay';
+const PRECACHE = `${CACHE_PREFIX}-precache-${APP_VERSION}`;
+const RUNTIME = `${CACHE_PREFIX}-runtime-${APP_VERSION}`;
+const API_CACHE = `${CACHE_PREFIX}-api-${APP_VERSION}`;
+const DB_NAME = 'agenticpay-offline-db';
+const DB_VERSION = 1;
+const PAYMENT_STORE = 'offline-payments';
+const SYNC_TAG = 'agenticpay-payment-sync';
+const PRECACHE_URLS = [
+  '/',
+  '/auth',
+  '/dashboard',
+  '/manifest.webmanifest',
+  '/icons/image-192.png',
+  '/icons/image-512.png',
+];
+const STATIC_DESTINATIONS = new Set(['script', 'style', 'image', 'font', 'manifest']);
 
-self.addEventListener("install", (event) => {
+self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => {
-      return cache.addAll(urlsToCache);
-    })
+    caches.open(PRECACHE).then(async (cache) => {
+      await cache.addAll(PRECACHE_URLS.map((url) => new Request(url, { cache: 'reload' })));
+    }),
   );
   self.skipWaiting();
 });
 
-self.addEventListener("activate", (event) => {
-  event.waitUntil(clients.claim());
-});
-
-self.addEventListener("fetch", (event) => {
-  event.respondWith(
-    caches.match(event.request).then((resp) => {
-      return resp || fetch(event.request);
-    })
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => key.startsWith(CACHE_PREFIX) && ![PRECACHE, RUNTIME, API_CACHE].includes(key))
+          .map((key) => caches.delete(key)),
+      );
+      await self.clients.claim();
+      await broadcast({ type: 'SW_ACTIVATED', version: APP_VERSION });
+    })(),
   );
 });
+
+self.addEventListener('fetch', (event) => {
+  const request = event.request;
+  const url = new URL(request.url);
+
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (request.method !== 'GET') {
+    if (isPaymentMutation(url.pathname)) {
+      event.respondWith(queuePaymentMutation(request));
+      return;
+    }
+
+    event.respondWith(fetch(request));
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirstDocument(request));
+    return;
+  }
+
+  if (url.pathname.startsWith('/api/')) {
+    event.respondWith(networkFirstApi(request));
+    return;
+  }
+
+  if (STATIC_DESTINATIONS.has(request.destination) || url.pathname.startsWith('/_next/static/')) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  event.respondWith(staleWhileRevalidate(request));
+});
+
+self.addEventListener('sync', (event) => {
+  if (event.tag === SYNC_TAG || event.tag === 'sync-payments') {
+    event.waitUntil(flushPaymentQueue());
+  }
+});
+
+self.addEventListener('message', (event) => {
+  const { type, payload } = event.data || {};
+
+  if (type === 'SKIP_WAITING') {
+    self.skipWaiting();
+    return;
+  }
+
+  if (type === 'QUEUE_PAYMENT') {
+    event.waitUntil(
+      savePayment({
+        id: payload?.id || crypto.randomUUID(),
+        endpoint: payload?.endpoint || '/api/v1/stellar/pay',
+        method: payload?.method || 'POST',
+        headers: payload?.headers || { 'content-type': 'application/json' },
+        body: payload?.body || JSON.stringify(payload?.payment || {}),
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        status: 'pending',
+        retryCount: 0,
+      }).then(registerSync).then(notifyQueueChanged),
+    );
+    return;
+  }
+
+  if (type === 'SYNC_NOW') {
+    event.waitUntil(flushPaymentQueue());
+    return;
+  }
+
+  if (type === 'GET_QUEUE_STATUS') {
+    event.waitUntil(
+      getQueuedPayments().then((items) => {
+        event.ports?.[0]?.postMessage({
+          pendingCount: items.filter((item) => item.status !== 'synced').length,
+          failedCount: items.filter((item) => item.status === 'failed').length,
+          version: APP_VERSION,
+        });
+      }),
+    );
+  }
+});
+
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+
+  const response = await fetch(request);
+  if (response.ok) {
+    await safeCachePut(RUNTIME, request, response.clone());
+  }
+  return response;
+}
+
+async function networkFirstDocument(request) {
+  try {
+    const response = await fetch(request);
+    if (response.ok) await safeCachePut(RUNTIME, request, response.clone());
+    return response;
+  } catch {
+    return (await caches.match(request)) || (await caches.match('/dashboard')) || (await caches.match('/')) || offlineResponse('Offline dashboard shell unavailable');
+  }
+}
+
+async function networkFirstApi(request) {
+  try {
+    const response = await fetch(request);
+    if (response.ok) await safeCachePut(API_CACHE, request, response.clone());
+    return response;
+  } catch {
+    const cached = await caches.match(request);
+    if (cached) {
+      const headers = new Headers(cached.headers);
+      headers.set('X-AgenticPay-Cache', 'stale');
+      return new Response(cached.body, { status: cached.status, statusText: cached.statusText, headers });
+    }
+    return new Response(JSON.stringify({ error: 'offline', message: 'Network unavailable and no cached API response exists.' }), {
+      status: 503,
+      headers: { 'content-type': 'application/json', 'X-AgenticPay-Offline': 'true' },
+    });
+  }
+}
+
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(RUNTIME);
+  const cached = await cache.match(request);
+  const network = fetch(request)
+    .then((response) => {
+      if (response.ok) void safeCachePut(RUNTIME, request, response.clone());
+      return response;
+    })
+    .catch(() => undefined);
+
+  return cached || (await network) || offlineResponse('Offline');
+}
+
+async function safeCachePut(cacheName, request, response) {
+  try {
+    const cache = await caches.open(cacheName);
+    await cache.put(request, response);
+  } catch (error) {
+    // Storage quota can be exceeded on mobile; evict runtime entries and continue serving network data.
+    if (error && (error.name === 'QuotaExceededError' || /quota/i.test(String(error.message)))) {
+      await caches.delete(RUNTIME);
+      await caches.delete(API_CACHE);
+    }
+  }
+}
+
+function offlineResponse(message) {
+  return new Response(message, { status: 503, headers: { 'content-type': 'text/plain', 'X-AgenticPay-Offline': 'true' } });
+}
+
+function isPaymentMutation(pathname) {
+  return pathname.includes('/pay') || pathname.includes('/payments') || pathname.includes('/stellar/pay');
+}
+
+async function queuePaymentMutation(request) {
+  try {
+    const clone = request.clone();
+    const online = typeof navigator === 'undefined' ? true : navigator.onLine;
+    if (online) {
+      return await fetch(request);
+    }
+
+    const payment = await requestToQueuedPayment(clone);
+    await savePayment(payment);
+    await registerSync();
+    await notifyQueueChanged();
+    return new Response(JSON.stringify({ queued: true, id: payment.id, offline: true }), {
+      status: 202,
+      headers: { 'content-type': 'application/json', 'X-AgenticPay-Offline-Queued': 'true' },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: 'offline_queue_failed', message: String(error?.message || error) }), {
+      status: 503,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}
+
+async function requestToQueuedPayment(request) {
+  return {
+    id: crypto.randomUUID(),
+    endpoint: new URL(request.url).pathname + new URL(request.url).search,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    body: await request.text(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    status: 'pending',
+    retryCount: 0,
+  };
+}
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(PAYMENT_STORE)) {
+        db.createObjectStore(PAYMENT_STORE, { keyPath: 'id' });
+      }
+    };
+  });
+}
+
+async function withStore(storeMode, operation) {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(PAYMENT_STORE, storeMode);
+    const store = transaction.objectStore(PAYMENT_STORE);
+    const request = operation(store);
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () => reject(transaction.error);
+  }).finally(() => db.close());
+}
+
+async function savePayment(payment) {
+  await withStore('readwrite', (store) => store.put({ ...payment, updatedAt: Date.now() }));
+}
+
+async function deletePayment(id) {
+  await withStore('readwrite', (store) => store.delete(id));
+}
+
+async function getQueuedPayments() {
+  return (await withStore('readonly', (store) => store.getAll())) || [];
+}
+
+async function flushPaymentQueue() {
+  const queued = await getQueuedPayments();
+  let synced = 0;
+  let failed = 0;
+
+  for (const item of queued) {
+    if (item.status === 'syncing') continue;
+
+    await savePayment({ ...item, status: 'syncing' });
+    try {
+      const response = await fetch(item.endpoint, {
+        method: item.method,
+        headers: { ...item.headers, 'X-AgenticPay-Offline-Replay': 'true' },
+        body: item.body,
+      });
+
+      if (response.ok || response.status === 409) {
+        await deletePayment(item.id);
+        synced += 1;
+      } else {
+        await savePayment({ ...item, status: 'failed', retryCount: (item.retryCount || 0) + 1, lastError: `HTTP ${response.status}` });
+        failed += 1;
+      }
+    } catch (error) {
+      await savePayment({ ...item, status: 'failed', retryCount: (item.retryCount || 0) + 1, lastError: String(error?.message || error) });
+      failed += 1;
+      break;
+    }
+  }
+
+  await broadcast({ type: 'PAYMENT_QUEUE_SYNCED', synced, failed, remaining: (await getQueuedPayments()).length });
+  return { synced, failed };
+}
+
+async function registerSync() {
+  if ('sync' in self.registration) {
+    await self.registration.sync.register(SYNC_TAG);
+  }
+}
+
+async function notifyQueueChanged() {
+  const remaining = (await getQueuedPayments()).length;
+  await broadcast({ type: 'PAYMENT_QUEUE_CHANGED', remaining });
+}
+
+async function broadcast(message) {
+  const clients = await self.clients.matchAll({ includeUncontrolled: true, type: 'window' });
+  for (const client of clients) {
+    client.postMessage(message);
+  }
+}

--- a/packages/types/src/exports.ts
+++ b/packages/types/src/exports.ts
@@ -205,3 +205,40 @@ export interface ApiError {
   statusCode: number;
   details?: Record<string, unknown>;
 }
+
+// ─── Result / Option primitives ──────────────────────────────────────────────
+
+export type Result<T, E = AppError> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+export type Option<T> = T | null | undefined;
+
+export interface AppError {
+  code: string;
+  message: string;
+  statusCode: number;
+  details?: Record<string, unknown>;
+  cause?: unknown;
+}
+
+export type ValidationAppError = AppError & { code: 'VALIDATION_ERROR'; statusCode: 400 };
+export type NotFoundAppError = AppError & { code: 'NOT_FOUND'; statusCode: 404 };
+export type ForbiddenAppError = AppError & { code: 'FORBIDDEN'; statusCode: 403 };
+export type ConflictAppError = AppError & { code: 'CONFLICT'; statusCode: 409 };
+
+export function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value };
+}
+
+export function err<E extends AppError>(error: E): Result<never, E> {
+  return { ok: false, error };
+}
+
+export function isOk<T, E>(result: Result<T, E>): result is { ok: true; value: T } {
+  return result.ok;
+}
+
+export function isErr<T, E>(result: Result<T, E>): result is { ok: false; error: E } {
+  return !result.ok;
+}


### PR DESCRIPTION
## What i did:

This PR implements the platform and frontend improvements across the PWA dashboard, route loading strategy, EVM contracts workflow, and backend error handling.

Closes #358  
Closes #369  
Closes #370  
Closes #374  

## What Changed

### PWA offline support

- Added a versioned service worker cache strategy for the app shell, static assets, runtime responses, and API responses.
- Implemented cache-first handling for static assets and network-first handling for dashboard documents and API data.
- Added stale API cache fallback responses when the network is unavailable.
- Added cache invalidation on service worker activation so stale app versions are removed safely.
- Added quota-aware cache eviction to handle storage pressure on constrained devices.
- Added an IndexedDB-backed offline payment queue.
- Added background sync support to replay queued payment mutations when connectivity returns.
- Broadcasts queue and sync state back to open clients so the UI can surface accurate offline status.

### Dashboard route code splitting

- Moved dashboard chart rendering into a dynamically imported component so heavy visualization dependencies are not included in the initial dashboard route chunk.
- Added a skeleton fallback while the async dashboard chart chunk loads.
- Added sidebar hover/focus prefetching for likely-next dashboard routes.
- Documented the bundle-analysis workflow for maintainers to compare before/after bundle output.

### EVM Hardhat workflow

- Added explicit TypeChain generation configuration for Ethers v6 bindings.
- Added gas reporter configuration.
- Added a contracts CI script that compiles contracts, generates TypeChain types, type-checks scripts/tests, and runs gas-reporting tests.
- Updated the EVM contracts GitHub Actions workflow to generate TypeChain bindings and run gas-reporting tests in CI.

### Result-based service error handling

- Added shared `Result<T, E>` / `Option<T>` primitives for package consumers.
- Added backend runtime Result helpers for service-layer code.
- Migrated project service expected business-rule failures to return Result values instead of throwing exceptions.
- Updated project controllers to map Result errors into HTTP responses at the controller boundary.
- Updated controller tests for the Result-based response behavior.
- Added a migration guide for incrementally moving other services to the Result pattern.


## Notes for Reviewers

This PR intentionally keeps each change scoped to the technical areas requested in the issues:

- PWA/service-worker offline behavior and queued payment replay.
- Dashboard route-level code splitting and route prefetching.
- EVM Hardhat TypeChain/gas-reporting CI improvements.
- Backend Result-pattern groundwork with one service/controller migration and documentation for follow-up migrations.