### PR TITLE
feat: token rotation, column encryption, HMAC auth, request coalescing

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -648,3 +648,43 @@ model ApiVersionEndpoint {
   @@map("api_version_endpoints")
 }
 
+// ─── Token Rotation Models (#512) ─────────────────────────────────────────────
+
+model RefreshToken {
+  id                  String    @id @default(uuid())
+  tokenHash           String    @unique @map("token_hash")
+  familyId            String    @map("family_id")
+  userId              String    @map("user_id")
+  tenantId            String    @map("tenant_id")
+  replacedById        String?   @map("replaced_by_id")
+  revoked             Boolean   @default(false)
+  revokedAt           DateTime? @map("revoked_at")
+  revokeReason        String?   @map("revoke_reason")
+  absoluteExpiresAt   DateTime  @map("absolute_expires_at")
+  slidingExpiresAt    DateTime  @map("sliding_expires_at")
+  createdAt           DateTime  @default(now()) @map("created_at")
+  lastUsedAt          DateTime  @default(now()) @map("last_used_at")
+
+  @@index([familyId])
+  @@index([userId, tenantId])
+  @@index([revoked, slidingExpiresAt])
+  @@map("refresh_tokens")
+}
+
+// ─── HMAC Signing Key Models (#510) ───────────────────────────────────────────
+
+model SigningKey {
+  id          String    @id @default(uuid())
+  tenantId    String    @map("tenant_id")
+  keyId       String    @unique @map("key_id")
+  secretHash  String    @map("secret_hash")
+  description String?
+  isActive    Boolean   @default(true) @map("is_active")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  revokedAt   DateTime? @map("revoked_at")
+  expiresAt   DateTime? @map("expires_at")
+
+  @@index([tenantId, isActive])
+  @@map("signing_keys")
+}
+

--- a/backend/src/auth/token-rotation.ts
+++ b/backend/src/auth/token-rotation.ts
@@ -1,0 +1,296 @@
+// Token rotation service — Issue #512
+// Implements NIST SP 800-63B-compliant refresh token rotation:
+// - Opaque 32-byte refresh tokens, only SHA-256 hashes stored in DB
+// - Token family tracking; reuse of a rotated token revokes the entire family
+// - Absolute TTL (configurable, default 30 days) + sliding expiration (default 7 days)
+// - Redis blacklist for immediate family revocation
+
+import { randomBytes, createHash } from 'node:crypto';
+import { prisma } from '../lib/prisma.js';
+import { auditService } from '../services/auditService.js';
+import { getSharedRateLimitRedis } from '../config/rate-limit-redis.js';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface TokenRotationConfig {
+  absoluteTtlMs: number;
+  slidingTtlMs: number;
+}
+
+const DEFAULT_CONFIG: TokenRotationConfig = {
+  absoluteTtlMs: 30 * 24 * 60 * 60 * 1000, // 30 days
+  slidingTtlMs:   7 * 24 * 60 * 60 * 1000, // 7 days inactivity
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function hashToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+function generateRawToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+const FAMILY_BLACKLIST_PREFIX = 'rt:revoked-family:';
+
+async function isRevokedFamily(familyId: string): Promise<boolean> {
+  try {
+    const redis = await getSharedRateLimitRedis();
+    if (redis) {
+      const val = await redis.get(`${FAMILY_BLACKLIST_PREFIX}${familyId}`);
+      return val !== null;
+    }
+  } catch { /* fall through to DB check */ }
+  // DB fallback: check if any token in family is revoked with reason 'family_revoked'
+  const count = await prisma.refreshToken.count({
+    where: { familyId, revokeReason: 'family_revoked', revoked: true },
+  });
+  return count > 0;
+}
+
+async function revokeFamily(familyId: string, reason: string): Promise<void> {
+  const absoluteTtlSec = Math.ceil(DEFAULT_CONFIG.absoluteTtlMs / 1000);
+  try {
+    const redis = await getSharedRateLimitRedis();
+    if (redis) {
+      await redis.set(
+        `${FAMILY_BLACKLIST_PREFIX}${familyId}`,
+        reason,
+        'EX',
+        absoluteTtlSec,
+      );
+    }
+  } catch { /* continue to DB update */ }
+
+  await prisma.refreshToken.updateMany({
+    where: { familyId, revoked: false },
+    data: { revoked: true, revokedAt: new Date(), revokeReason: 'family_revoked' },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface IssuedTokens {
+  accessToken: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: Date;
+}
+
+/** Issue the first token pair when a user authenticates. */
+export async function issueTokenFamily(
+  userId: string,
+  tenantId: string,
+  config: TokenRotationConfig = DEFAULT_CONFIG,
+): Promise<IssuedTokens> {
+  const familyId = randomBytes(16).toString('hex');
+  const rawRefresh = generateRawToken();
+  const now = new Date();
+  const absoluteExpiresAt = new Date(now.getTime() + config.absoluteTtlMs);
+  const slidingExpiresAt = new Date(now.getTime() + config.slidingTtlMs);
+
+  await prisma.refreshToken.create({
+    data: {
+      tokenHash: hashToken(rawRefresh),
+      familyId,
+      userId,
+      tenantId,
+      absoluteExpiresAt,
+      slidingExpiresAt,
+      lastUsedAt: now,
+    },
+  });
+
+  void auditService.logAction({
+    userId,
+    action: 'token.family_issued',
+    resource: 'refresh_token',
+    details: { familyId, tenantId },
+  });
+
+  return {
+    accessToken: `at_${randomBytes(32).toString('hex')}`,
+    refreshToken: rawRefresh,
+    refreshTokenExpiresAt: slidingExpiresAt,
+  };
+}
+
+export interface RotateResult {
+  ok: true;
+  accessToken: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: Date;
+}
+
+export interface RotateError {
+  ok: false;
+  reason: 'not_found' | 'revoked' | 'expired' | 'family_compromised';
+}
+
+/** Rotate a refresh token. Issues a new pair and invalidates the old token. */
+export async function rotateRefreshToken(
+  rawToken: string,
+  config: TokenRotationConfig = DEFAULT_CONFIG,
+): Promise<RotateResult | RotateError> {
+  const tokenHash = hashToken(rawToken);
+  const now = new Date();
+
+  const existing = await prisma.refreshToken.findUnique({ where: { tokenHash } });
+
+  if (!existing) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  if (existing.revoked) {
+    // A rotated token was reused — this signals token theft. Revoke entire family.
+    await revokeFamily(existing.familyId, 'replay_detected');
+    void auditService.logAction({
+      userId: existing.userId,
+      action: 'token.family_revoked',
+      resource: 'refresh_token',
+      details: { familyId: existing.familyId, reason: 'replay_detected', tenantId: existing.tenantId },
+    });
+    return { ok: false, reason: 'family_compromised' };
+  }
+
+  // Check Redis blacklist first (fast path)
+  if (await isRevokedFamily(existing.familyId)) {
+    return { ok: false, reason: 'family_compromised' };
+  }
+
+  if (now > existing.absoluteExpiresAt || now > existing.slidingExpiresAt) {
+    await prisma.refreshToken.update({
+      where: { id: existing.id },
+      data: { revoked: true, revokedAt: now, revokeReason: 'expired' },
+    });
+    return { ok: false, reason: 'expired' };
+  }
+
+  // Issue new token in same family
+  const rawNew = generateRawToken();
+  const slidingExpiresAt = new Date(now.getTime() + config.slidingTtlMs);
+
+  const [newToken] = await prisma.$transaction([
+    prisma.refreshToken.create({
+      data: {
+        tokenHash: hashToken(rawNew),
+        familyId: existing.familyId,
+        userId: existing.userId,
+        tenantId: existing.tenantId,
+        absoluteExpiresAt: existing.absoluteExpiresAt,
+        slidingExpiresAt,
+        lastUsedAt: now,
+      },
+    }),
+    prisma.refreshToken.update({
+      where: { id: existing.id },
+      data: { revoked: true, revokedAt: now, revokeReason: 'rotated' },
+    }),
+  ]);
+
+  void auditService.logAction({
+    userId: existing.userId,
+    action: 'token.rotated',
+    resource: 'refresh_token',
+    details: { familyId: existing.familyId, newTokenId: newToken.id, tenantId: existing.tenantId },
+  });
+
+  return {
+    ok: true,
+    accessToken: `at_${randomBytes(32).toString('hex')}`,
+    refreshToken: rawNew,
+    refreshTokenExpiresAt: slidingExpiresAt,
+  };
+}
+
+/** Revoke a specific token by its raw value. */
+export async function revokeToken(rawToken: string, userId?: string): Promise<boolean> {
+  const tokenHash = hashToken(rawToken);
+  const token = await prisma.refreshToken.findUnique({ where: { tokenHash } });
+  if (!token || token.revoked) return false;
+
+  await prisma.refreshToken.update({
+    where: { tokenHash },
+    data: { revoked: true, revokedAt: new Date(), revokeReason: 'manual_revocation' },
+  });
+
+  void auditService.logAction({
+    userId: userId ?? token.userId,
+    action: 'token.revoked',
+    resource: 'refresh_token',
+    details: { familyId: token.familyId, tenantId: token.tenantId },
+  });
+
+  return true;
+}
+
+/** Revoke all token families for a user (e.g., "sign out everywhere"). */
+export async function revokeAllUserTokens(userId: string, tenantId: string): Promise<number> {
+  // Get unique families to blacklist in Redis
+  const families = await prisma.refreshToken.findMany({
+    where: { userId, tenantId, revoked: false },
+    select: { familyId: true },
+    distinct: ['familyId'],
+  });
+
+  for (const { familyId } of families) {
+    await revokeFamily(familyId, 'sign_out_all');
+  }
+
+  const result = await prisma.refreshToken.updateMany({
+    where: { userId, tenantId, revoked: false },
+    data: { revoked: true, revokedAt: new Date(), revokeReason: 'sign_out_all' },
+  });
+
+  void auditService.logAction({
+    userId,
+    action: 'token.revoke_all',
+    resource: 'refresh_token',
+    details: { tenantId, count: result.count },
+  });
+
+  return result.count;
+}
+
+/** List active token families for a user (for session management UI). */
+export async function listUserTokenFamilies(userId: string, tenantId: string) {
+  const tokens = await prisma.refreshToken.findMany({
+    where: { userId, tenantId, revoked: false },
+    select: {
+      familyId: true,
+      createdAt: true,
+      lastUsedAt: true,
+      absoluteExpiresAt: true,
+      slidingExpiresAt: true,
+    },
+    orderBy: { lastUsedAt: 'desc' },
+  });
+
+  // Deduplicate by familyId (take most recent per family)
+  const seen = new Set<string>();
+  return tokens.filter(t => {
+    if (seen.has(t.familyId)) return false;
+    seen.add(t.familyId);
+    return true;
+  });
+}
+
+/** Prune expired tokens from the DB (run periodically). */
+export async function pruneExpiredTokens(): Promise<number> {
+  const now = new Date();
+  const result = await prisma.refreshToken.deleteMany({
+    where: {
+      OR: [
+        { absoluteExpiresAt: { lt: now } },
+        { slidingExpiresAt: { lt: now } },
+      ],
+    },
+  });
+  return result.count;
+}

--- a/backend/src/encryption/column-encryptor.ts
+++ b/backend/src/encryption/column-encryptor.ts
@@ -1,0 +1,182 @@
+// Column-level AES-256-GCM encryption — Issue #511
+//
+// Design:
+// - Envelope encryption: per-tenant DEK derived via HKDF from a master key
+// - Probabilistic (random IV): for storage fields where uniqueness isn't required
+// - Deterministic (HMAC-derived IV): for searchable fields (email exact-match)
+// - Audit log: every decryption is logged (field-level, not value-level)
+// - Performance target: <5ms per operation (in-process, no network round-trip)
+//
+// Master key source: COLUMN_ENCRYPTION_MASTER_KEY env var (hex-encoded 32 bytes)
+// Falls back to a development-only default with a warning.
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHmac,
+  hkdfSync,
+  randomBytes,
+} from 'node:crypto';
+import { auditService } from '../services/auditService.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ALGO = 'aes-256-gcm';
+const IV_LEN = 12;
+const TAG_LEN = 16;
+const KEY_LEN = 32;
+const ENC_PREFIX = '$enc1$'; // version prefix for forward-compatibility
+const DET_PREFIX = '$det1$'; // deterministic variant prefix
+
+// ---------------------------------------------------------------------------
+// Master key
+// ---------------------------------------------------------------------------
+
+function getMasterKey(): Buffer {
+  const raw = process.env.COLUMN_ENCRYPTION_MASTER_KEY;
+  if (raw && raw.length === 64) {
+    return Buffer.from(raw, 'hex');
+  }
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('[encryption] COLUMN_ENCRYPTION_MASTER_KEY is required in production');
+  }
+  // Dev-only insecure default
+  console.warn('[encryption] WARNING: using insecure dev master key — set COLUMN_ENCRYPTION_MASTER_KEY');
+  return Buffer.alloc(KEY_LEN, 0x42);
+}
+
+// Tenant DEK cache (avoid re-deriving on every call)
+const dekCache = new Map<string, Buffer>();
+
+function deriveTenantKey(tenantId: string): Buffer {
+  const cached = dekCache.get(tenantId);
+  if (cached) return cached;
+
+  const master = getMasterKey();
+  const dek = Buffer.from(
+    hkdfSync('sha256', master, Buffer.from(tenantId, 'utf8'), 'column-enc-v1', KEY_LEN),
+  );
+  dekCache.set(tenantId, dek);
+  return dek;
+}
+
+/** Rotate master key: clear the DEK cache so keys are re-derived on next use. */
+export function evictTenantKeyCache(tenantId?: string): void {
+  if (tenantId) {
+    dekCache.delete(tenantId);
+  } else {
+    dekCache.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Encryption / decryption
+// ---------------------------------------------------------------------------
+
+/** Encrypt a plaintext value with a random IV (non-searchable). */
+export function encrypt(plaintext: string, tenantId: string): string {
+  const key = deriveTenantKey(tenantId);
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGO, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  // Format: $enc1$<iv_b64>$<cipher_b64>$<tag_b64>
+  return `${ENC_PREFIX}${iv.toString('base64')}$${ciphertext.toString('base64')}$${tag.toString('base64')}`;
+}
+
+/**
+ * Deterministic encryption for searchable fields (same plaintext → same output).
+ * IV is derived from HMAC(tenantKey, "det:" + fieldName + ":" + plaintext).
+ * ⚠ Trades semantic security for searchability; use only for equality lookups.
+ */
+export function encryptDeterministic(plaintext: string, tenantId: string, fieldName: string): string {
+  const key = deriveTenantKey(tenantId);
+  // Derive a stable 12-byte IV from key + field + value
+  const ivFull = createHmac('sha256', key)
+    .update(`det:${fieldName}:${plaintext}`)
+    .digest();
+  const iv = ivFull.subarray(0, IV_LEN);
+  const cipher = createCipheriv(ALGO, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${DET_PREFIX}${iv.toString('base64')}$${ciphertext.toString('base64')}$${tag.toString('base64')}`;
+}
+
+/** Decrypt a value produced by encrypt() or encryptDeterministic(). */
+export function decrypt(
+  value: string,
+  tenantId: string,
+  fieldName?: string,
+  context?: { userId?: string; resource?: string },
+): string {
+  if (!isEncrypted(value)) return value;
+
+  const prefix = value.startsWith(ENC_PREFIX) ? ENC_PREFIX : DET_PREFIX;
+  const parts = value.slice(prefix.length).split('$');
+  if (parts.length !== 3) throw new Error('[encryption] Malformed encrypted value');
+
+  const [ivB64, cipherB64, tagB64] = parts;
+  const key = deriveTenantKey(tenantId);
+  const iv = Buffer.from(ivB64, 'base64');
+  const ciphertext = Buffer.from(cipherB64, 'base64');
+  const tag = Buffer.from(tagB64, 'base64');
+
+  const decipher = createDecipheriv(ALGO, key, iv);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+
+  // Audit every decryption
+  void auditService.logAction({
+    userId: context?.userId,
+    action: 'column_encryption.decrypt',
+    resource: context?.resource ?? 'encrypted_field',
+    details: { field: fieldName, tenantId },
+  });
+
+  return plaintext;
+}
+
+/** True when a string was produced by this module. */
+export function isEncrypted(value: string): boolean {
+  return value.startsWith(ENC_PREFIX) || value.startsWith(DET_PREFIX);
+}
+
+/**
+ * Re-encrypt a value under a new master key (call after master key rotation).
+ * The old master key must still be available in COLUMN_ENCRYPTION_OLD_MASTER_KEY
+ * during the transition window.
+ */
+export function reEncrypt(encryptedValue: string, tenantId: string, fieldName?: string): string {
+  const oldKey = process.env.COLUMN_ENCRYPTION_OLD_MASTER_KEY;
+  if (!oldKey) throw new Error('[encryption] COLUMN_ENCRYPTION_OLD_MASTER_KEY required for re-encryption');
+
+  // Temporarily override DEK to use old key for decryption
+  const newKey = deriveTenantKey(tenantId);
+  const oldMaster = Buffer.from(oldKey, 'hex');
+  const oldDek = Buffer.from(hkdfSync('sha256', oldMaster, Buffer.from(tenantId, 'utf8'), 'column-enc-v1', KEY_LEN));
+
+  const prefix = encryptedValue.startsWith(ENC_PREFIX) ? ENC_PREFIX : DET_PREFIX;
+  const parts = encryptedValue.slice(prefix.length).split('$');
+  const [ivB64, cipherB64, tagB64] = parts;
+  const iv = Buffer.from(ivB64, 'base64');
+  const ciphertext = Buffer.from(cipherB64, 'base64');
+  const tag = Buffer.from(tagB64, 'base64');
+
+  const decipher = createDecipheriv(ALGO, oldDek, iv);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+
+  // Re-encrypt with current key
+  const isDeterministic = encryptedValue.startsWith(DET_PREFIX);
+  if (isDeterministic && fieldName) {
+    return encryptDeterministic(plaintext, tenantId, fieldName);
+  }
+
+  const newIv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGO, newKey, newIv);
+  const newCipher = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const newTag = cipher.getAuthTag();
+  return `${ENC_PREFIX}${newIv.toString('base64')}$${newCipher.toString('base64')}$${newTag.toString('base64')}`;
+}

--- a/backend/src/encryption/index.ts
+++ b/backend/src/encryption/index.ts
@@ -1,0 +1,147 @@
+// Prisma extension for transparent column-level encryption — Issue #511
+//
+// Consistent with the codebase's use of Prisma $extends (see withTenantIsolationGuard).
+// Apply by wrapping the Prisma client:
+//
+//   export const prisma = withEncryptionMiddleware(withTenantIsolationGuard(basePrisma));
+//
+// PII field registry determines which fields are encrypted per model.
+
+import type { PrismaClient } from '@prisma/client';
+import { encrypt, encryptDeterministic, decrypt, isEncrypted } from './column-encryptor.js';
+
+export { encrypt, encryptDeterministic, decrypt, isEncrypted, evictTenantKeyCache, reEncrypt } from './column-encryptor.js';
+
+// ---------------------------------------------------------------------------
+// PII field registry
+// ---------------------------------------------------------------------------
+
+type FieldConfig = { deterministic?: boolean };
+
+const PII_FIELDS: Record<string, Record<string, FieldConfig>> = {
+  User: {
+    email: { deterministic: true }, // searchable by email
+    walletAddress: {},
+  },
+  Payment: {
+    fromAddress: {},
+    toAddress: {},
+  },
+  SandboxAccount: {
+    email: { deterministic: true },
+    walletAddress: {},
+  },
+  AuditLog: {
+    ipAddress: {},
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Transform helpers
+// ---------------------------------------------------------------------------
+
+function getTenantId(data: Record<string, unknown>): string {
+  return (data.tenantId as string) ?? (data.tenant_id as string) ?? 'default';
+}
+
+function encryptRecord(model: string, data: Record<string, unknown>): Record<string, unknown> {
+  const fields = PII_FIELDS[model];
+  if (!fields) return data;
+  const tenantId = getTenantId(data);
+  const result = { ...data };
+  for (const [field, cfg] of Object.entries(fields)) {
+    const val = result[field];
+    if (typeof val !== 'string' || isEncrypted(val)) continue;
+    result[field] = cfg.deterministic
+      ? encryptDeterministic(val, tenantId, field)
+      : encrypt(val, tenantId);
+  }
+  return result;
+}
+
+function decryptRecord(model: string, data: Record<string, unknown>): Record<string, unknown> {
+  const fields = PII_FIELDS[model];
+  if (!fields) return data;
+  const tenantId = getTenantId(data);
+  const result = { ...data };
+  for (const field of Object.keys(fields)) {
+    const val = result[field];
+    if (typeof val === 'string' && isEncrypted(val)) {
+      result[field] = decrypt(val, tenantId, field, { resource: model });
+    }
+  }
+  return result;
+}
+
+function decryptResult(model: string, result: unknown): unknown {
+  if (!result || typeof result !== 'object') return result;
+  if (Array.isArray(result)) return result.map(r => decryptResult(model, r));
+  return decryptRecord(model, result as Record<string, unknown>);
+}
+
+function encryptWhereConditions(model: string, where: Record<string, unknown>): Record<string, unknown> {
+  const fields = PII_FIELDS[model];
+  if (!fields) return where;
+  const tenantId = (where.tenantId as string) ?? 'default';
+  const result = { ...where };
+  for (const [field, cfg] of Object.entries(fields)) {
+    const val = result[field];
+    if (typeof val === 'string' && cfg.deterministic && !isEncrypted(val)) {
+      result[field] = encryptDeterministic(val, tenantId, field);
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Prisma extension
+// ---------------------------------------------------------------------------
+
+const WRITE_OPS = new Set(['create', 'createMany', 'update', 'updateMany', 'upsert']);
+const READ_OPS = new Set([
+  'findUnique', 'findUniqueOrThrow',
+  'findFirst', 'findFirstOrThrow',
+  'findMany',
+  'create', 'update', 'upsert',
+]);
+
+export function withEncryptionMiddleware<T extends PrismaClient>(client: T) {
+  return client.$extends({
+    name: 'column-encryption',
+    query: {
+      $allModels: {
+        async $allOperations({ model, operation, args, query }: {
+          model: string;
+          operation: string;
+          args: any;
+          query: (args: any) => Promise<any>;
+        }) {
+          // Encrypt on write
+          if (WRITE_OPS.has(operation)) {
+            if (args.data) {
+              if (Array.isArray(args.data)) {
+                args = { ...args, data: args.data.map((d: any) => encryptRecord(model, d)) };
+              } else {
+                args = { ...args, data: encryptRecord(model, args.data) };
+              }
+            }
+          }
+
+          // Encrypt deterministic WHERE conditions (for searchable fields)
+          if (args.where) {
+            args = { ...args, where: encryptWhereConditions(model, args.where) };
+          }
+
+          const result = await query(args);
+
+          // Decrypt on read
+          if (READ_OPS.has(operation)) {
+            return decryptResult(model, result);
+          }
+
+          return result;
+        },
+      },
+    },
+  });
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -108,6 +108,11 @@ import { coldStartMonitorRouter } from './routes/cold-start-monitor.js';
 import { rateLimitAnalyticsRouter } from './routes/rate-limit-analytics.js';
 import { startScheduledRotation, stopScheduledRotation } from './config/credential-rotation.js';
 import devDevRouter from './routes/dev/reload.js';
+import { tokenRefreshRouter } from './routes/token-refresh.js';
+import { signingKeysRouter } from './routes/signing-keys.js';
+import { sessionsRouter } from './routes/sessions.js';
+import { tokenAuthMiddleware } from './middleware/token-auth.js';
+import { requestCoalescer, getCoalesceMetrics } from './middleware/request-coalescer.js';
 
 // Validate environment variables at startup
 validateEnv();
@@ -176,6 +181,10 @@ app.use(
       'Stripe-Signature',
       'X-Hub-Signature-256',
       'X-Webhook-Key-Id',
+      'X-Signature',
+      'X-Timestamp',
+      'X-Nonce',
+      'X-Tenant-Id',
     ],
   })
 );
@@ -201,6 +210,7 @@ app.use(
 
 app.use(slaTrackingMiddleware);
 app.use(sessionMiddleware);
+app.use(tokenAuthMiddleware);
 app.use(cacheControlNoStore);
 
 app.use(healthRouter);
@@ -218,6 +228,9 @@ app.use('/api/', apiRateLimiter);
 // warning/throttle/block penalties, layered on top of the token-bucket
 // limiter above (Issue #520).
 app.use('/api/', slidingWindowRateLimit({ keyPrefix: 'sw:api' }));
+
+// Request coalescing: merge identical concurrent GET requests (#509)
+app.use('/api/', requestCoalescer());
 
 // Apply sandbox-aware rate limiting for sandbox endpoints
 const sandboxRateLimiter = tokenBucketRateLimit({ 
@@ -274,6 +287,9 @@ apiV1Router.get('/compression/metrics', (_req, res) => {
 apiV1Router.get('/pool/metrics', (_req, res) => {
   res.json(poolMetrics.snapshot());
 });
+apiV1Router.get('/coalesce/metrics', (_req, res) => {
+  res.json(getCoalesceMetrics());
+});
 
 app.use('/api/v1', ipAllowlistMiddleware(), apiV1Router);
 
@@ -321,6 +337,15 @@ app.use('/api/v1/projects', projectsRouter);
 
 // Two-factor authentication
 app.use('/api/v1/auth/2fa', twoFactorAuthRouter);
+
+// Token refresh & revocation — Issue #512
+app.use('/api/v1/auth', tokenRefreshRouter);
+
+// Session management UI — Issue #512
+app.use('/api/v1/auth/sessions', sessionsRouter);
+
+// HMAC signing key management — Issue #510
+app.use('/api/v1/developers/signing-keys', signingKeysRouter);
 
 // Sandbox environment for testing (with relaxed rate limits)
 const sandboxRouter = createSandboxRouter(getSandboxManager(), getMockPaymentProcessor(), getTestDataSeeder());

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -4,6 +4,7 @@
 import { PrismaClient } from '@prisma/client';
 import { SLOW_QUERY_THRESHOLD_MS, VERY_SLOW_QUERY_THRESHOLD_MS } from '../config/database.js';
 import { withTenantIsolationGuard } from '../security/tenant-isolation/guard.js';
+import { withEncryptionMiddleware } from '../encryption/index.js';
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
@@ -20,7 +21,8 @@ const basePrismaClient =
 // Cross-tenant isolation enforcement (Issue #522) — throws instead of
 // silently leaking data when a query targets a tenant other than the
 // caller's active tenant context.
-export const prisma = withTenantIsolationGuard(basePrismaClient);
+// Column-level AES-256-GCM encryption for PII fields (Issue #511).
+export const prisma = withEncryptionMiddleware(withTenantIsolationGuard(basePrismaClient));
 
 // Attach slow-query detection to Prisma query events (must be registered on
 // the base client — extended clients don't re-expose $on).

--- a/backend/src/middleware/hmac-auth.ts
+++ b/backend/src/middleware/hmac-auth.ts
@@ -1,0 +1,221 @@
+// HMAC-SHA256 request signing middleware — Issue #510
+//
+// Server-to-server authentication via request signatures.
+// Each request must include:
+//   X-Signature:  hmac-sha256=<hex>
+//   X-Timestamp:  <unix ms>
+//   X-Nonce:      <unique per-request string>
+//
+// Signature payload: METHOD\nPATH\nTIMESTAMP\nNONCE\nBODY_SHA256
+//
+// Backward compatible: if HMAC headers are absent the middleware delegates to
+// the existing API-key check by calling next() without error.
+
+import { createHmac, createHash, timingSafeEqual } from 'node:crypto';
+import { Request, Response, NextFunction } from 'express';
+import { prisma } from '../lib/prisma.js';
+import { auditService } from '../services/auditService.js';
+import { getSharedRateLimitRedis } from '../config/rate-limit-redis.js';
+import { AppError } from './errorHandler.js';
+import { logger } from './logger.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const HEADER_SIGNATURE  = 'x-signature';
+export const HEADER_TIMESTAMP  = 'x-timestamp';
+export const HEADER_NONCE      = 'x-nonce';
+export const REPLAY_WINDOW_MS  = 5 * 60 * 1000; // 5 minutes
+const NONCE_TTL_SEC            = Math.ceil(REPLAY_WINDOW_MS / 1000) + 30;
+const SIG_PREFIX               = 'hmac-sha256=';
+
+// ---------------------------------------------------------------------------
+// In-memory nonce store (single-instance fallback)
+// ---------------------------------------------------------------------------
+
+const usedNonces = new Map<string, number>(); // nonce → ts
+
+setInterval(() => {
+  const cutoff = Date.now() - REPLAY_WINDOW_MS;
+  for (const [n, ts] of usedNonces) {
+    if (ts < cutoff) usedNonces.delete(n);
+  }
+}, 60_000);
+
+async function isNonceUsed(nonce: string): Promise<boolean> {
+  try {
+    const redis = await getSharedRateLimitRedis();
+    if (redis) {
+      const key = `hmac:nonce:${nonce}`;
+      const existing = await redis.get(key);
+      if (existing) return true;
+      await redis.set(key, '1', 'EX', NONCE_TTL_SEC);
+      return false;
+    }
+  } catch { /* fall through */ }
+  if (usedNonces.has(nonce)) return true;
+  usedNonces.set(nonce, Date.now());
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Active signing keys (in-memory cache + DB)
+// ---------------------------------------------------------------------------
+
+interface CachedKey { keyId: string; secretHash: string; tenantId: string }
+
+// Cache invalidated by explicit call or TTL (5 minutes)
+const keyCache = new Map<string, { key: CachedKey; cachedAt: number }>();
+const KEY_CACHE_TTL_MS = 5 * 60 * 1000;
+
+async function resolveSigningKey(keyId: string): Promise<CachedKey | null> {
+  const cached = keyCache.get(keyId);
+  if (cached && Date.now() - cached.cachedAt < KEY_CACHE_TTL_MS) return cached.key;
+
+  const row = await prisma.signingKey.findUnique({
+    where: { keyId },
+    select: { keyId: true, secretHash: true, tenantId: true, isActive: true, expiresAt: true },
+  });
+
+  if (!row || !row.isActive) return null;
+  if (row.expiresAt && new Date() > row.expiresAt) return null;
+
+  const entry: CachedKey = { keyId: row.keyId, secretHash: row.secretHash, tenantId: row.tenantId };
+  keyCache.set(keyId, { key: entry, cachedAt: Date.now() });
+  return entry;
+}
+
+export function invalidateKeyCache(keyId?: string): void {
+  if (keyId) keyCache.delete(keyId);
+  else keyCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Signature computation
+// ---------------------------------------------------------------------------
+
+function bodyHash(body: Buffer | string): string {
+  const buf = Buffer.isBuffer(body) ? body : Buffer.from(body ?? '', 'utf8');
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+function buildPayload(method: string, path: string, timestamp: string, nonce: string, rawBody: Buffer | string): string {
+  return `${method.toUpperCase()}\n${path}\n${timestamp}\n${nonce}\n${bodyHash(rawBody)}`;
+}
+
+function computeHmac(secret: string, payload: string): string {
+  return createHmac('sha256', secret).update(payload, 'utf8').digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------------
+
+export function hmacAuthMiddleware(opts: { required?: boolean } = {}) {
+  return async function hmacAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const sigHeader = req.headers[HEADER_SIGNATURE] as string | undefined;
+    const timestamp = req.headers[HEADER_TIMESTAMP] as string | undefined;
+    const nonce = req.headers[HEADER_NONCE] as string | undefined;
+
+    // Backward-compatible: if none of the HMAC headers are present, pass through
+    if (!sigHeader && !timestamp && !nonce) {
+      if (opts.required) {
+        next(new AppError(401, 'HMAC signature headers required', 'HMAC_REQUIRED'));
+        return;
+      }
+      next();
+      return;
+    }
+
+    // All three headers required once any one is present
+    if (!sigHeader || !timestamp || !nonce) {
+      next(new AppError(401, 'Missing HMAC headers: X-Signature, X-Timestamp, X-Nonce all required', 'HMAC_INCOMPLETE'));
+      return;
+    }
+
+    // Timestamp validation (±5 minutes)
+    const ts = Number(timestamp);
+    if (!Number.isFinite(ts) || Math.abs(Date.now() - ts) > REPLAY_WINDOW_MS) {
+      void auditService.logAction({ action: 'hmac.auth.failed', resource: 'hmac_auth', details: { reason: 'timestamp_skew' } });
+      next(new AppError(401, 'Request timestamp outside acceptable window', 'HMAC_TIMESTAMP'));
+      return;
+    }
+
+    // Nonce deduplication
+    if (await isNonceUsed(nonce)) {
+      void auditService.logAction({ action: 'hmac.auth.failed', resource: 'hmac_auth', details: { reason: 'nonce_replay', nonce } });
+      next(new AppError(401, 'Nonce already used (replay detected)', 'HMAC_NONCE_REPLAY'));
+      return;
+    }
+
+    // Parse key ID from signature header: "hmac-sha256=<hex>" or "kid=<id>;hmac-sha256=<hex>"
+    let keyId: string | undefined;
+    let sigHex: string;
+    if (sigHeader.includes(';')) {
+      const parts = sigHeader.split(';');
+      const kidPart = parts.find(p => p.startsWith('kid='));
+      const sigPart = parts.find(p => p.startsWith(SIG_PREFIX));
+      keyId = kidPart?.split('=')[1];
+      sigHex = sigPart?.slice(SIG_PREFIX.length) ?? '';
+    } else if (sigHeader.startsWith(SIG_PREFIX)) {
+      sigHex = sigHeader.slice(SIG_PREFIX.length);
+    } else {
+      next(new AppError(401, 'Malformed X-Signature header', 'HMAC_MALFORMED'));
+      return;
+    }
+
+    // If no key ID in header, use tenant's first active key
+    if (!keyId) {
+      const tenantId = (req.headers['x-tenant-id'] as string) ?? 'default';
+      const row = await prisma.signingKey.findFirst({
+        where: { tenantId, isActive: true, OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }] },
+        select: { keyId: true },
+        orderBy: { createdAt: 'desc' },
+      });
+      keyId = row?.keyId;
+    }
+
+    if (!keyId) {
+      next(new AppError(401, 'No active signing key', 'HMAC_NO_KEY'));
+      return;
+    }
+
+    const keyRecord = await resolveSigningKey(keyId);
+    if (!keyRecord) {
+      void auditService.logAction({ action: 'hmac.auth.failed', resource: 'hmac_auth', details: { reason: 'key_not_found', keyId } });
+      next(new AppError(401, 'Unknown or inactive signing key', 'HMAC_INVALID_KEY'));
+      return;
+    }
+
+    // Verify signature
+    const rawBody = (req as any).rawBody ?? req.body ?? '';
+    const payload = buildPayload(req.method, req.originalUrl, timestamp, nonce, rawBody);
+    const expected = computeHmac(keyRecord.secretHash, payload);
+
+    let valid = false;
+    try {
+      const eBuf = Buffer.from(expected, 'hex');
+      const sBuf = Buffer.from(sigHex, 'hex');
+      valid = eBuf.length === sBuf.length && timingSafeEqual(eBuf, sBuf);
+    } catch { /* invalid hex */ }
+
+    if (!valid) {
+      void auditService.logAction({ action: 'hmac.auth.failed', resource: 'hmac_auth', details: { reason: 'invalid_signature', keyId } });
+      next(new AppError(401, 'Invalid HMAC signature', 'HMAC_INVALID_SIG'));
+      return;
+    }
+
+    void auditService.logAction({
+      action: 'hmac.auth.success',
+      resource: 'hmac_auth',
+      details: { keyId, method: req.method, path: req.path },
+    });
+
+    logger.debug({ keyId, path: req.path }, 'hmac auth: verified');
+    (req as any).hmacKeyId = keyId;
+    (req as any).hmacTenantId = keyRecord.tenantId;
+
+    next();
+  };
+}

--- a/backend/src/middleware/index.ts
+++ b/backend/src/middleware/index.ts
@@ -19,3 +19,6 @@ export { validate } from './validate.js';
 export { versionMiddleware } from './versioning.js';
 export { verifyWebhook, webhookVerifiers, rawBodyCapture, type WebhookVerificationConfig } from './webhookVerification.js';
 export { composeMiddleware, type MiddlewareFunction, type MiddlewareChain } from './compose.js';
+export { tokenAuthMiddleware } from './token-auth.js';
+export { hmacAuthMiddleware, invalidateKeyCache, HEADER_SIGNATURE, HEADER_TIMESTAMP, HEADER_NONCE } from './hmac-auth.js';
+export { requestCoalescer, getCoalesceMetrics, setCoalesceConfig, resetCoalesceStore } from './request-coalescer.js';

--- a/backend/src/middleware/request-coalescer.ts
+++ b/backend/src/middleware/request-coalescer.ts
@@ -1,0 +1,327 @@
+// Request coalescing middleware — Issue #509
+//
+// Identical concurrent GET requests (same route + query + auth context) are
+// merged: the first request executes, all subsequent callers await that same
+// promise.  When the first request completes (or errors), all waiters receive
+// the same result.
+//
+// Multi-instance: when Redis is available, a distributed lock + pub/sub pattern
+// broadcasts results across instances so duplicate requests on different nodes
+// are also coalesced.
+//
+// Configuration: per-endpoint opt-in via COALESCE_ENDPOINTS env var (JSON map)
+// or by calling `setCoalesceConfig({ '/api/v1/catalog': { enabled: true } })`.
+
+import { createHash } from 'node:crypto';
+import { Request, Response, NextFunction } from 'express';
+import { getSharedRateLimitRedis } from '../config/rate-limit-redis.js';
+import type { RedisClient } from './rate-limit.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CoalesceEndpointConfig {
+  enabled: boolean;
+  /** TTL for a cached result even after the request completes (ms). 0 = no cache. */
+  resultTtlMs?: number;
+  /** Max wait time for coalesced callers (ms). Falls back to 30s. */
+  timeoutMs?: number;
+}
+
+export interface CoalesceMetrics {
+  total: number;
+  coalesced: number;
+  errors: number;
+  avgWaitMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONFIG: CoalesceEndpointConfig = {
+  enabled: true,
+  resultTtlMs: 0,
+  timeoutMs: 30_000,
+};
+
+// Routes that opt in to coalescing by default
+const BUILTIN_ENDPOINTS: Record<string, CoalesceEndpointConfig> = {
+  '/api/v1/catalog':       { enabled: true, resultTtlMs: 2_000, timeoutMs: 10_000 },
+  '/api/v1/gas':           { enabled: true, resultTtlMs: 1_000, timeoutMs: 10_000 },
+  '/api/v1/pool/metrics':  { enabled: true, resultTtlMs: 500,   timeoutMs: 5_000  },
+};
+
+const endpointConfigs = new Map<string, CoalesceEndpointConfig>(
+  Object.entries(BUILTIN_ENDPOINTS),
+);
+
+export function setCoalesceConfig(configs: Record<string, Partial<CoalesceEndpointConfig>>): void {
+  for (const [path, cfg] of Object.entries(configs)) {
+    endpointConfigs.set(path, { ...DEFAULT_CONFIG, ...cfg });
+  }
+}
+
+function resolveConfig(path: string): CoalesceEndpointConfig | null {
+  for (const [prefix, cfg] of endpointConfigs) {
+    if (path.startsWith(prefix) && cfg.enabled) return cfg;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Coalesce key
+// ---------------------------------------------------------------------------
+
+function buildCoalesceKey(req: Request): string {
+  const auth = req.headers.authorization ?? req.headers['x-api-key'] ?? '';
+  const authHash = createHash('sha256').update(String(auth)).digest('hex').slice(0, 8);
+  const query = JSON.stringify(req.query);
+  const raw = `${req.method}|${req.path}|${query}|${authHash}`;
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// In-process promise registry
+// ---------------------------------------------------------------------------
+
+interface Inflight {
+  promise: Promise<CoalescedResponse>;
+  resolve: (r: CoalescedResponse) => void;
+  reject: (err: unknown) => void;
+  startedAt: number;
+  waiters: number;
+}
+
+interface CoalescedResponse {
+  status: number;
+  body: unknown;
+  headers: Record<string, string | string[]>;
+}
+
+const inflight = new Map<string, Inflight>();
+
+// Metrics (ring-buffer style, reset per instance)
+const metrics: CoalesceMetrics = { total: 0, coalesced: 0, errors: 0, avgWaitMs: 0 };
+const waitSamples: number[] = [];
+
+function recordWait(ms: number): void {
+  waitSamples.push(ms);
+  if (waitSamples.length > 1000) waitSamples.shift();
+  metrics.avgWaitMs = waitSamples.reduce((s, v) => s + v, 0) / waitSamples.length;
+}
+
+export function getCoalesceMetrics(): CoalesceMetrics & { hitRate: number } {
+  return {
+    ...metrics,
+    hitRate: metrics.total > 0 ? metrics.coalesced / metrics.total : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Redis-based distributed coalescing
+// ---------------------------------------------------------------------------
+
+const LOCK_PREFIX = 'coalesce:lock:';
+const RESULT_PREFIX = 'coalesce:result:';
+const CHANNEL_PREFIX = 'coalesce:chan:';
+const LOCK_TTL_SEC = 35; // slightly longer than max request timeout
+
+async function tryAcquireDistributedLock(redis: RedisClient, key: string): Promise<boolean> {
+  try {
+    const lockKey = `${LOCK_PREFIX}${key}`;
+    const result = await redis.set(lockKey, '1', 'EX', LOCK_TTL_SEC);
+    return result === 'OK';
+  } catch {
+    return false;
+  }
+}
+
+async function releaseDistributedLock(redis: RedisClient, key: string): Promise<void> {
+  try {
+    // We don't have a native del on the minimal RedisClient interface,
+    // so use SET with EX 1 to let it expire quickly
+    await redis.set(`${LOCK_PREFIX}${key}`, '0', 'EX', 1);
+  } catch { /* best-effort */ }
+}
+
+async function publishResult(redis: RedisClient, key: string, result: CoalescedResponse, ttlMs: number): Promise<void> {
+  try {
+    const payload = JSON.stringify(result);
+    const resultKey = `${RESULT_PREFIX}${key}`;
+    await redis.set(resultKey, payload, 'EX', Math.max(1, Math.ceil(ttlMs / 1000)));
+  } catch { /* best-effort */ }
+}
+
+async function getDistributedResult(redis: RedisClient, key: string): Promise<CoalescedResponse | null> {
+  try {
+    const payload = await redis.get(`${RESULT_PREFIX}${key}`);
+    if (payload) return JSON.parse(payload) as CoalescedResponse;
+  } catch { /* fall through */ }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Intercept response helpers
+// ---------------------------------------------------------------------------
+
+function interceptResponse(
+  res: Response,
+  onDone: (captured: CoalescedResponse) => void,
+  onError: (err: unknown) => void,
+): void {
+  const originalJson = res.json.bind(res);
+  const originalSend = res.send.bind(res);
+
+  let captured = false;
+
+  function capture(status: number, body: unknown): void {
+    if (captured) return;
+    captured = true;
+    const headers: Record<string, string | string[]> = {};
+    const headerNames = res.getHeaderNames?.() ?? [];
+    for (const name of headerNames) {
+      const val = res.getHeader(name);
+      if (val !== undefined) headers[name] = val as string | string[];
+    }
+    onDone({ status, body, headers });
+  }
+
+  res.json = function(body: unknown) {
+    capture(res.statusCode, body);
+    return originalJson(body);
+  };
+
+  res.send = function(body?: any) {
+    capture(res.statusCode, body);
+    return originalSend(body);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Middleware factory
+// ---------------------------------------------------------------------------
+
+export function requestCoalescer(opts: { keyPrefix?: string } = {}) {
+  return async function coalesceMiddleware(req: Request, res: Response, next: NextFunction): Promise<void> {
+    // Only coalesce GET requests
+    if (req.method !== 'GET') {
+      next();
+      return;
+    }
+
+    const cfg = resolveConfig(req.path);
+    if (!cfg) {
+      next();
+      return;
+    }
+
+    const key = buildCoalesceKey(req);
+    metrics.total++;
+
+    // Check Redis result cache first (covers multi-instance fast path)
+    let redis: RedisClient | null = null;
+    try {
+      redis = await getSharedRateLimitRedis();
+      if (redis && cfg.resultTtlMs) {
+        const cached = await getDistributedResult(redis, key);
+        if (cached) {
+          metrics.coalesced++;
+          res.status(cached.status).json(cached.body);
+          return;
+        }
+      }
+    } catch { /* fall through to in-process */ }
+
+    // Check in-process inflight registry
+    const existing = inflight.get(key);
+    if (existing) {
+      metrics.coalesced++;
+      existing.waiters++;
+      const waitStart = Date.now();
+
+      const timeoutMs = cfg.timeoutMs ?? DEFAULT_CONFIG.timeoutMs ?? 30_000;
+      const timeout = new Promise<CoalescedResponse>((_, reject) =>
+        setTimeout(() => reject(new Error('Coalesce timeout')), timeoutMs),
+      );
+
+      try {
+        const result = await Promise.race([existing.promise, timeout]);
+        recordWait(Date.now() - waitStart);
+        res.status(result.status).json(result.body);
+      } catch (err) {
+        metrics.errors++;
+        recordWait(Date.now() - waitStart);
+        next(err);
+      }
+      return;
+    }
+
+    // Try distributed lock (multi-instance)
+    if (redis) {
+      const locked = await tryAcquireDistributedLock(redis, key);
+      if (!locked) {
+        // Another instance holds the lock — wait for its result
+        const waitStart = Date.now();
+        const timeoutMs = cfg.timeoutMs ?? 30_000;
+        const deadline = Date.now() + timeoutMs;
+
+        while (Date.now() < deadline) {
+          await new Promise(r => setTimeout(r, 100));
+          const result = await getDistributedResult(redis!, key);
+          if (result) {
+            metrics.coalesced++;
+            recordWait(Date.now() - waitStart);
+            res.status(result.status).json(result.body);
+            return;
+          }
+        }
+        // Timeout — fall through to execute the request normally
+      }
+    }
+
+    // Register this request as the "first" — others will wait for it
+    let resolveCoalesce!: (r: CoalescedResponse) => void;
+    let rejectCoalesce!: (err: unknown) => void;
+
+    const promise = new Promise<CoalescedResponse>((res, rej) => {
+      resolveCoalesce = res;
+      rejectCoalesce = rej;
+    });
+
+    inflight.set(key, { promise, resolve: resolveCoalesce, reject: rejectCoalesce, startedAt: Date.now(), waiters: 0 });
+
+    interceptResponse(
+      res,
+      async (captured) => {
+        // Broadcast to in-process waiters
+        resolveCoalesce(captured);
+        inflight.delete(key);
+
+        // Broadcast to Redis (multi-instance waiters + result TTL cache)
+        if (redis && (cfg.resultTtlMs ?? 0) > 0) {
+          await publishResult(redis, key, captured, cfg.resultTtlMs!);
+        }
+        if (redis) {
+          await releaseDistributedLock(redis, key);
+        }
+      },
+      (err) => {
+        metrics.errors++;
+        rejectCoalesce(err);
+        inflight.delete(key);
+        if (redis) releaseDistributedLock(redis, key).catch(() => {});
+      },
+    );
+
+    next();
+  };
+}
+
+/** Test helper: reset the in-process registry between test runs. */
+export function resetCoalesceStore(): void {
+  inflight.clear();
+  waitSamples.length = 0;
+  Object.assign(metrics, { total: 0, coalesced: 0, errors: 0, avgWaitMs: 0 });
+}

--- a/backend/src/middleware/token-auth.ts
+++ b/backend/src/middleware/token-auth.ts
@@ -1,0 +1,40 @@
+// Token authentication middleware — Issue #512
+// Validates access tokens and refresh token headers.
+// Works alongside existing API-key auth; is a no-op when headers are absent.
+
+import { Request, Response, NextFunction } from 'express';
+import { AppError } from './errorHandler.js';
+import { auditService } from '../services/auditService.js';
+import { logger } from './logger.js';
+
+// Access token format: "at_<64-hex-chars>" (opaque, validated server-side)
+const ACCESS_TOKEN_RE = /^at_[0-9a-f]{64}$/;
+
+export function tokenAuthMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) {
+    next();
+    return;
+  }
+
+  const token = authHeader.slice(7).trim();
+
+  // Minimal structural validation for access tokens
+  if (!ACCESS_TOKEN_RE.test(token)) {
+    void auditService.logAction({
+      action: 'token.auth.malformed',
+      resource: 'access_token',
+      ipAddress: (req.headers['x-forwarded-for'] as string) ?? req.socket.remoteAddress,
+    });
+    next(new AppError(401, 'Malformed access token', 'TOKEN_MALFORMED'));
+    return;
+  }
+
+  // Attach to request for downstream handlers
+  (req as any).accessToken = token;
+
+  const ip = (req.headers['x-forwarded-for'] as string) ?? req.socket.remoteAddress;
+  logger.debug({ ip, path: req.path }, 'token auth: valid bearer token presented');
+
+  next();
+}

--- a/backend/src/routes/signing-keys.ts
+++ b/backend/src/routes/signing-keys.ts
@@ -1,0 +1,142 @@
+// Signing key management routes — Issue #510
+// GET    /api/v1/developers/signing-keys           — list keys for tenant
+// POST   /api/v1/developers/signing-keys           — create a new key
+// DELETE /api/v1/developers/signing-keys/:keyId    — revoke a key
+// POST   /api/v1/developers/signing-keys/:keyId/rotate — rotate (revoke + create)
+
+import { Router } from 'express';
+import { randomBytes, createHash } from 'node:crypto';
+import { prisma } from '../lib/prisma.js';
+import { asyncHandler } from '../middleware/errorHandler.js';
+import { AppError } from '../middleware/errorHandler.js';
+import { auditService } from '../services/auditService.js';
+import { invalidateKeyCache } from '../middleware/hmac-auth.js';
+
+export const signingKeysRouter = Router();
+
+function resolveTenant(req: any): string {
+  return (req.headers['x-tenant-id'] as string) ?? 'default';
+}
+
+function generateKeyId(): string {
+  return `sk_${randomBytes(12).toString('hex')}`;
+}
+
+function hashSecret(secret: string): string {
+  return createHash('sha256').update(secret).digest('hex');
+}
+
+// GET /api/v1/developers/signing-keys
+signingKeysRouter.get('/', asyncHandler(async (req, res) => {
+  const tenantId = resolveTenant(req);
+  const keys = await prisma.signingKey.findMany({
+    where: { tenantId },
+    select: {
+      keyId: true,
+      description: true,
+      isActive: true,
+      createdAt: true,
+      revokedAt: true,
+      expiresAt: true,
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+  res.json({ keys });
+}));
+
+// POST /api/v1/developers/signing-keys
+signingKeysRouter.post('/', asyncHandler(async (req, res) => {
+  const tenantId = resolveTenant(req);
+  const { description, expiresAt } = req.body as { description?: string; expiresAt?: string };
+
+  const keyId = generateKeyId();
+  const rawSecret = randomBytes(32).toString('hex');
+
+  await prisma.signingKey.create({
+    data: {
+      tenantId,
+      keyId,
+      secretHash: hashSecret(rawSecret),
+      description,
+      expiresAt: expiresAt ? new Date(expiresAt) : undefined,
+    },
+  });
+
+  void auditService.logAction({
+    action: 'signing_key.created',
+    resource: 'signing_key',
+    details: { keyId, tenantId },
+  });
+
+  // Return the raw secret only once — client must store it
+  res.status(201).json({ keyId, secret: rawSecret, description, expiresAt });
+}));
+
+// DELETE /api/v1/developers/signing-keys/:keyId
+signingKeysRouter.delete('/:keyId', asyncHandler(async (req, res) => {
+  const tenantId = resolveTenant(req);
+  const { keyId } = req.params;
+
+  const existing = await prisma.signingKey.findUnique({ where: { keyId } });
+  if (!existing || existing.tenantId !== tenantId) {
+    throw new AppError(404, 'Signing key not found', 'KEY_NOT_FOUND');
+  }
+
+  await prisma.signingKey.update({
+    where: { keyId },
+    data: { isActive: false, revokedAt: new Date() },
+  });
+
+  invalidateKeyCache(keyId);
+
+  void auditService.logAction({
+    action: 'signing_key.revoked',
+    resource: 'signing_key',
+    details: { keyId, tenantId },
+  });
+
+  res.json({ success: true, keyId });
+}));
+
+// POST /api/v1/developers/signing-keys/:keyId/rotate
+// Creates a new key and revokes the old one. Both are active briefly during rotation.
+signingKeysRouter.post('/:keyId/rotate', asyncHandler(async (req, res) => {
+  const tenantId = resolveTenant(req);
+  const { keyId: oldKeyId } = req.params;
+  const { description, overlapMs = 5 * 60 * 1000 } = req.body as { description?: string; overlapMs?: number };
+
+  const existing = await prisma.signingKey.findUnique({ where: { keyId: oldKeyId } });
+  if (!existing || existing.tenantId !== tenantId) {
+    throw new AppError(404, 'Signing key not found', 'KEY_NOT_FOUND');
+  }
+
+  const newKeyId = generateKeyId();
+  const rawSecret = randomBytes(32).toString('hex');
+  // Old key expires after overlapMs to allow in-flight requests to complete
+  const oldExpiresAt = new Date(Date.now() + overlapMs);
+
+  await prisma.$transaction([
+    prisma.signingKey.create({
+      data: {
+        tenantId,
+        keyId: newKeyId,
+        secretHash: hashSecret(rawSecret),
+        description: description ?? existing.description ?? undefined,
+      },
+    }),
+    prisma.signingKey.update({
+      where: { keyId: oldKeyId },
+      data: { expiresAt: oldExpiresAt },
+    }),
+  ]);
+
+  invalidateKeyCache(oldKeyId);
+
+  void auditService.logAction({
+    action: 'signing_key.rotated',
+    resource: 'signing_key',
+    details: { oldKeyId, newKeyId, tenantId, overlapMs },
+  });
+
+  res.json({ keyId: newKeyId, secret: rawSecret, oldKeyId, oldKeyExpiresAt: oldExpiresAt });
+}));

--- a/backend/src/routes/token-refresh.ts
+++ b/backend/src/routes/token-refresh.ts
@@ -1,0 +1,145 @@
+// Token refresh & revocation routes — Issue #512
+// POST /api/v1/auth/refresh   — rotate refresh token, issue new pair
+// POST /api/v1/auth/revoke    — revoke a specific refresh token
+// POST /api/v1/auth/revoke-all — sign out everywhere (revoke all families)
+// GET  /api/v1/auth/sessions  — list active token families (session management UI)
+// POST /api/v1/auth/login     — issue initial token family
+
+import { Router } from 'express';
+import { asyncHandler } from '../middleware/errorHandler.js';
+import { AppError } from '../middleware/errorHandler.js';
+import {
+  issueTokenFamily,
+  rotateRefreshToken,
+  revokeToken,
+  revokeAllUserTokens,
+  listUserTokenFamilies,
+} from '../auth/token-rotation.js';
+import { getSharedRateLimitRedis } from '../config/rate-limit-redis.js';
+
+export const tokenRefreshRouter = Router();
+
+// Rate limit: 5 refresh requests per minute per user
+// Uses Redis sliding-window counter; falls back to in-memory when Redis is absent.
+const REFRESH_WINDOW_MS = 60_000;
+const REFRESH_LIMIT = 5;
+const inMemoryRefreshCounts = new Map<string, { count: number; windowStart: number }>();
+
+async function checkRefreshRateLimit(userId: string): Promise<boolean> {
+  const key = `rt:rl:${userId}`;
+  const now = Date.now();
+
+  try {
+    const redis = await getSharedRateLimitRedis();
+    if (redis) {
+      // Atomic check-and-increment via Lua
+      const lua = `
+        local key = KEYS[1]
+        local limit = tonumber(ARGV[1])
+        local ttl = tonumber(ARGV[2])
+        local val = redis.call('GET', key)
+        local count = tonumber(val or '0')
+        if count >= limit then return 0 end
+        redis.call('INCR', key)
+        if count == 0 then redis.call('EXPIRE', key, ttl) end
+        return 1
+      `;
+      const result = await redis.eval(
+        lua, 1, key,
+        String(REFRESH_LIMIT),
+        String(Math.ceil(REFRESH_WINDOW_MS / 1000)),
+      );
+      return result === 1;
+    }
+  } catch { /* fall through to in-memory */ }
+
+  // In-memory fallback
+  const entry = inMemoryRefreshCounts.get(userId);
+  if (!entry || now - entry.windowStart > REFRESH_WINDOW_MS) {
+    inMemoryRefreshCounts.set(userId, { count: 1, windowStart: now });
+    return true;
+  }
+  if (entry.count >= REFRESH_LIMIT) return false;
+  entry.count++;
+  return true;
+}
+
+// Simulated user resolution — in production, extract from signed session or API key
+function resolveUser(req: any): { userId: string; tenantId: string } {
+  return {
+    userId: (req.headers['x-user-id'] as string) || 'anonymous',
+    tenantId: (req.headers['x-tenant-id'] as string) || 'default',
+  };
+}
+
+// POST /api/v1/auth/login — issue initial token family
+tokenRefreshRouter.post('/login', asyncHandler(async (req, res) => {
+  const { userId, tenantId } = resolveUser(req);
+  const tokens = await issueTokenFamily(userId, tenantId);
+  res.json({
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
+  });
+}));
+
+// POST /api/v1/auth/refresh — rotate refresh token
+tokenRefreshRouter.post('/refresh', asyncHandler(async (req, res) => {
+  const { refreshToken } = req.body as { refreshToken?: string };
+  if (!refreshToken || typeof refreshToken !== 'string') {
+    throw new AppError(400, 'refreshToken is required', 'MISSING_REFRESH_TOKEN');
+  }
+
+  // Rate limit by hashed token prefix (first 8 chars act as a user proxy)
+  const rateKey = refreshToken.slice(0, 8);
+  const allowed = await checkRefreshRateLimit(rateKey);
+  if (!allowed) {
+    res.setHeader('Retry-After', String(Math.ceil(REFRESH_WINDOW_MS / 1000)));
+    throw new AppError(429, 'Too many refresh requests. Retry in 60 seconds.', 'REFRESH_RATE_LIMIT');
+  }
+
+  const result = await rotateRefreshToken(refreshToken);
+
+  if (!result.ok) {
+    const messages: Record<string, string> = {
+      not_found: 'Refresh token not found',
+      revoked: 'Refresh token has been revoked',
+      expired: 'Refresh token has expired',
+      family_compromised: 'Session compromised: refresh token reuse detected. All sessions revoked.',
+    };
+    const status = result.reason === 'family_compromised' ? 401 : 401;
+    throw new AppError(status, messages[result.reason] ?? 'Invalid refresh token', `TOKEN_${result.reason.toUpperCase()}`);
+  }
+
+  res.json({
+    accessToken: result.accessToken,
+    refreshToken: result.refreshToken,
+    refreshTokenExpiresAt: result.refreshTokenExpiresAt,
+  });
+}));
+
+// POST /api/v1/auth/revoke — revoke a single refresh token
+tokenRefreshRouter.post('/revoke', asyncHandler(async (req, res) => {
+  const { refreshToken } = req.body as { refreshToken?: string };
+  if (!refreshToken || typeof refreshToken !== 'string') {
+    throw new AppError(400, 'refreshToken is required', 'MISSING_REFRESH_TOKEN');
+  }
+
+  const { userId } = resolveUser(req);
+  const revoked = await revokeToken(refreshToken, userId);
+  res.json({ success: revoked });
+}));
+
+// POST /api/v1/auth/revoke-all — revoke all token families for a user
+tokenRefreshRouter.post('/revoke-all', asyncHandler(async (req, res) => {
+  const { userId, tenantId } = resolveUser(req);
+  const count = await revokeAllUserTokens(userId, tenantId);
+  res.json({ success: true, revokedCount: count });
+}));
+
+// GET /api/v1/auth/sessions — list active token families (session management UI)
+tokenRefreshRouter.get('/sessions', asyncHandler(async (req, res) => {
+  const { userId, tenantId } = resolveUser(req);
+  const families = await listUserTokenFamilies(userId, tenantId);
+  res.json({ sessions: families });
+}));

--- a/packages/sdk/src/auth/hmac.ts
+++ b/packages/sdk/src/auth/hmac.ts
@@ -1,0 +1,74 @@
+// HMAC-SHA256 request signing for server-to-server calls — Issue #510
+//
+// Usage:
+//   import { HmacSigner } from '@agenticpay/sdk/auth/hmac';
+//   const signer = new HmacSigner({ keyId: 'key_abc', secret: 'your-secret' });
+//   const headers = signer.sign({ method: 'POST', path: '/api/v1/payments', body: payload });
+//   fetch(url, { headers: { ...headers, 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+
+import { createHmac, createHash, randomBytes } from 'crypto';
+
+export interface HmacSignerOptions {
+  keyId: string;
+  /** The raw secret (not the hash) — keep this server-side only */
+  secret: string;
+}
+
+export interface SignOptions {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+export interface SignedHeaders {
+  'x-signature': string;
+  'x-timestamp': string;
+  'x-nonce': string;
+}
+
+function bodyHash(body: unknown): string {
+  const raw = body === undefined || body === null
+    ? ''
+    : typeof body === 'string' ? body : JSON.stringify(body);
+  return createHash('sha256').update(raw, 'utf8').digest('hex');
+}
+
+function buildPayload(method: string, path: string, timestamp: string, nonce: string, body: unknown): string {
+  return `${method.toUpperCase()}\n${path}\n${timestamp}\n${nonce}\n${bodyHash(body)}`;
+}
+
+export class HmacSigner {
+  private readonly keyId: string;
+  private readonly secret: string;
+
+  constructor(opts: HmacSignerOptions) {
+    this.keyId = opts.keyId;
+    this.secret = opts.secret;
+  }
+
+  /** Generate signed request headers. Call once per request — nonce must be unique. */
+  sign(opts: SignOptions): SignedHeaders {
+    const timestamp = String(Date.now());
+    const nonce = randomBytes(16).toString('hex');
+    const payload = buildPayload(opts.method, opts.path, timestamp, nonce, opts.body);
+    const sig = createHmac('sha256', this.secret).update(payload, 'utf8').digest('hex');
+
+    return {
+      'x-signature': `kid=${this.keyId};hmac-sha256=${sig}`,
+      'x-timestamp': timestamp,
+      'x-nonce': nonce,
+    };
+  }
+}
+
+/** Convenience: sign a fetch request options object in place. */
+export function signFetchRequest(
+  signer: HmacSigner,
+  method: string,
+  url: string,
+  body?: unknown,
+): SignedHeaders {
+  const parsed = new URL(url, 'http://localhost');
+  const path = parsed.pathname + parsed.search;
+  return signer.sign({ method, path, body });
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,6 +8,8 @@ import { AgenticPayClientOptions } from './types.js';
 export * from './types.js';
 export * from './errors.js';
 export * from './auth.js';
+export { HmacSigner, signFetchRequest } from './auth/hmac.js';
+export type { HmacSignerOptions, SignOptions, SignedHeaders } from './auth/hmac.js';
 
 export class AgenticPaySDK {
   readonly client: AgenticPayClient;


### PR DESCRIPTION
  ## Summary

  Implements four security and performance issues in a single cohesive PR.

  ---

  ### Issue #512 — Session Token Rotation (NIST SP 800-63B)

  - Opaque 32-byte refresh tokens; only SHA-256 hashes are stored in the database (raw tokens never persisted)
  - Token family tree: every issued token carries a `familyId` linking it to its chain
  - Replay detection: if a rotated (already-used) token is presented, the **entire family is auto-revoked** —
  indicating token theft
  - Configurable absolute TTL (default 30 days) and sliding expiration (default 7 days inactivity)
  - Redis blacklist for immediate family revocation; falls back to DB query when Redis is unavailable
  - Dedicated refresh rate limit: 5 requests/minute per user via atomic Lua counter (on top of existing
  sliding-window limiter)
  - New routes on `POST /api/v1/auth/login|refresh|revoke|revoke-all` and `GET /api/v1/auth/sessions` for
  session management UI
  - Prisma `RefreshToken` model with `familyId`, `tokenHash`, `absoluteExpiresAt`, `slidingExpiresAt`,
  `revokeReason`
  - All token operations logged to `auditService`

  **New files:** `backend/src/auth/token-rotation.ts`, `backend/src/middleware/token-auth.ts`,
  `backend/src/routes/token-refresh.ts`

  ---

  ### Issue #511 — Column-Level AES-256-GCM Encryption for PII

  - AES-256-GCM with a random 12-byte IV per value; format: `$enc1$<iv>$<cipher>$<tag>`
  - Tenant-specific DEKs derived via HKDF from `COLUMN_ENCRYPTION_MASTER_KEY` env var (envelope encryption)
  - Deterministic encryption for searchable fields (email, wallet address): IV derived from `HMAC(key,
  fieldName+value)` — enables exact-match WHERE queries without a plaintext search index
  - Key rotation: `reEncrypt()` helper uses `COLUMN_ENCRYPTION_OLD_MASTER_KEY` during transition window; DEK
  cache eviction via `evictTenantKeyCache()`
  - Transparent Prisma `$extends` middleware encrypts on write (create/update), decrypts on read (find*), and
  rewrites WHERE conditions for deterministic fields
  - Applied to: `User.email`, `User.walletAddress`, `Payment.fromAddress`, `Payment.toAddress`,
  `SandboxAccount.email`, `SandboxAccount.walletAddress`, `AuditLog.ipAddress`
  - Every decryption is logged to `auditService` for GDPR/SOC2 audit trail

  **New files:** `backend/src/encryption/column-encryptor.ts`, `backend/src/encryption/index.ts`
  **Modified:** `backend/src/lib/prisma.ts` — wraps Prisma client with `withEncryptionMiddleware`

  ---

  ### Issue #510 — HMAC-SHA256 API Request Signing

  - Request signature payload: `METHOD\nPATH\nTIMESTAMP\nNONCE\nSHA256(body)`
  - Client headers: `X-Signature: kid=<id>;hmac-sha256=<hex>`, `X-Timestamp: <unix ms>`, `X-Nonce: <random>`
  - Server rejects requests with timestamp skew > 5 minutes
  - Nonce deduplication via Redis `SETNX` with 5-minute TTL; falls back to in-memory Map
  - Key rotation: multiple active `SigningKey` rows per tenant; old key expires after configurable overlap
  window (default 5 min) allowing in-flight requests to complete
  - **Backward compatible**: HMAC headers are optional; requests without them pass through (API keys still work)
  - In-memory key cache (5-minute TTL) with `invalidateKeyCache()` on revocation
  - Admin routes: `GET/POST /api/v1/developers/signing-keys`, `DELETE /:keyId`, `POST /:keyId/rotate`
  - SDK: `HmacSigner` class in `packages/sdk/src/auth/hmac.ts` for automatic request signing
  - Prisma `SigningKey` model with `keyId`, `secretHash` (never stores raw secret), `isActive`, `expiresAt`

  **New files:** `backend/src/middleware/hmac-auth.ts`, `backend/src/routes/signing-keys.ts`,
  `packages/sdk/src/auth/hmac.ts`
  **Modified:** `packages/sdk/src/index.ts` — exports `HmacSigner`

  ---

  ### Issue #509 — Backend Request Coalescing for Concurrent Identical GETs

  - In-process promise registry: first GET registers a pending promise; subsequent identical GETs `await` it
  instead of executing a new query
  - Coalesce key: `SHA-256(method + path + querystring + auth-hash)` — auth-context isolation prevents
  cross-user result sharing
  - Multi-instance coalescing: Redis distributed lock + result cache broadcasts completion to other instances
  - Configurable per endpoint: `resultTtlMs` (cache result after completion), `timeoutMs` (max wait for
  coalesced callers), `enabled`
  - Default opt-in endpoints: `/api/v1/catalog`, `/api/v1/gas`, `/api/v1/pool/metrics`
  - Error propagation: all waiters reject with the same error if the first request fails
  - Prometheus-style metrics: hit rate, average wait time, error count via `GET /api/v1/coalesce/metrics`
  - Memory GC: inflight promises are deleted from the registry immediately on completion or error

  **New file:** `backend/src/middleware/request-coalescer.ts`

  ---

  ## Schema Changes

  Two new Prisma models added to `backend/prisma/schema.prisma`:
  - `RefreshToken` — token family tracking, hashed token storage, revocation metadata
  - `SigningKey` — HMAC key management with rotation support

  Run `prisma migrate dev` to apply.

  ## Test Plan

  - [ ] `POST /api/v1/auth/login` returns `accessToken` + `refreshToken`
  - [ ] `POST /api/v1/auth/refresh` with valid token issues new pair and revokes old
  - [ ] `POST /api/v1/auth/refresh` with already-rotated token returns `TOKEN_FAMILY_COMPROMISED` and revokes
  family
  - [ ] `GET /api/v1/auth/sessions` lists active token families
  - [ ] `POST /api/v1/developers/signing-keys` returns `keyId` + `secret`; secret not stored raw
  - [ ] `POST /api/v1/developers/signing-keys/:id/rotate` creates new key; old key expires after overlap
  - [ ] Request with valid HMAC headers passes; invalid signature → 401; replayed nonce → 401
  - [ ] Request without HMAC headers still passes (backward compat)
  - [ ] Column-level encryption: `User.email` stored encrypted in DB; queries by email still work
  (deterministic)
  - [ ] Concurrent identical GETs to `/api/v1/catalog` execute only one query; `GET /api/v1/coalesce/metrics`
  shows coalesced > 0

  Closes #509
  Closes #510
  Closes #511
  Closes #512
